### PR TITLE
feat(http): backend-compatible HTTP layer with shared foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A production-ready, feature-packed starter template for Next.js applications. Bu
 - **Framework** — Next.js 16 (App Router, React Compiler, `proxy.ts` edge interception), React 19, TypeScript 6, Tailwind v4.
 - **i18n** — `next-intl` with locale-scoped routes under `src/app/[locale]/`, server-configured `timeZone` to avoid hydration mismatches.
 - **State** — Redux Toolkit + redux-persist with a per-request store (`useRef`-based), SSR-safe storage (`src/store/storage.ts`), and `preloadedState` support for Server Component → Redux hydration.
-- **HTTP** — dual client support (`axiosClient` and `fetchClient`) sharing a token-refresh manager and a rich `ApiException` (status / code / errors / data / path).
+- **HTTP** — dual clients (`fetchClient` + `axiosClient`) on a shared foundation (`src/lib/utils/http/shared/`): runtime-aware cookie forwarding (browser jar in CSR, `next/headers` injection in RSC), automatic `X-Request-Id` correlation with the backend, single `parseApiError` error pipeline, cookie-mode auth by default with a one-flag flip to bearer-mode. Backend-compatible response envelope, pagination (offset + cursor), and base query types ship out of the box.
 - **Env validation** — zod-validated, cached at module load (`src/lib/env/`). Add a variable in one place and type-safety, validation, and coercion flow everywhere.
 - **Logger** — pino with env-aware transports (pretty in dev, JSON to stdout in prod, silent in test) and automatic redaction of tokens / passwords / auth headers.
 - **Theme** — `@teispace/next-themes` (drop-in replacement for the unmaintained `next-themes`).
@@ -77,7 +77,7 @@ cp .env.example .env
 
 | Variable               | Description                                                                        | Default                 |
 | :--------------------- | :--------------------------------------------------------------------------------- | :---------------------- |
-| `NEXT_PUBLIC_API_URL`  | Base URL for the backing API. Empty → relative/proxied requests.                   | `(empty)`               |
+| `NEXT_PUBLIC_API_URL`  | Bare origin of the backing API (e.g. `https://api.example.com`). The `/api/v{n}` URI-version prefix is appended internally — do not include it here. Empty → relative/proxied requests. | `(empty)`               |
 | `NEXT_PUBLIC_APP_URL`  | Public URL this app is served from (used for OG/canonical URLs).                   | `http://localhost:3000` |
 | `DEFAULT_TIMEZONE`     | IANA time zone for server-rendered date formatting. Keeps SSR deterministic.       | `UTC`                   |
 | `DEFAULT_LOCALE`       | Fallback locale when a request locale cannot be resolved.                          | `en`                    |

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -79,10 +79,11 @@ nextjs-starter/
 │   │
 │   ├── lib/                                    # Core utilities and configurations
 │   │   ├── config/                             # App configuration
-│   │   │   ├── app-apis.ts
+│   │   │   ├── api-url.ts                      # getApiBaseUrl() — bare origin + /api/v1
+│   │   │   ├── app-apis.ts                     # Backend endpoint paths
 │   │   │   ├── app-locales.ts
 │   │   │   ├── app-paths.ts
-│   │   │   ├── constants.ts
+│   │   │   ├── constants.ts                    # API_PREFIX, SAVE_AUTH_TOKENS, env flags
 │   │   │   ├── seo.ts                          # SEO/metadata config
 │   │   │   └── index.ts
 │   │   ├── enums/
@@ -100,22 +101,30 @@ nextjs-starter/
 │   │   │   ├── index.ts                        # Configured logger export
 │   │   │   └── constants.ts                    # Levels + sensitive-key redaction paths
 │   │   ├── utils/
-│   │   │   ├── http/                           # HTTP client utilities
-│   │   │   │   ├── axios-client/               # Axios-based client
+│   │   │   ├── http/                           # HTTP clients (backend-compatible transport)
+│   │   │   │   ├── shared/                     # DRY foundation used by both clients
+│   │   │   │   │   ├── cookie-injection.ts     # Runtime-aware Cookie header (CSR vs RSC)
+│   │   │   │   │   ├── server-cookies.ts       # `server-only` next/headers reader
+│   │   │   │   │   ├── request-id.ts           # X-Request-Id generation + extractors
+│   │   │   │   │   ├── response-parser.ts      # Single parseApiError for both clients
+│   │   │   │   │   ├── runtime.ts              # isBrowser / isServer
+│   │   │   │   │   ├── search-params.ts        # Typed query object → URLSearchParams
+│   │   │   │   │   └── index.ts
+│   │   │   │   ├── axios-client/               # Axios adapter on the shared foundation
 │   │   │   │   │   ├── axios-client.ts
 │   │   │   │   │   ├── client.ts
 │   │   │   │   │   ├── index.ts
 │   │   │   │   │   ├── interceptors.ts
 │   │   │   │   │   └── token-refresh.ts
-│   │   │   │   ├── fetch-client/               # Fetch-based client
+│   │   │   │   ├── fetch-client/               # Fetch adapter on the shared foundation
 │   │   │   │   │   ├── client.ts
 │   │   │   │   │   ├── fetch-client.ts
 │   │   │   │   │   ├── index.ts
 │   │   │   │   │   ├── interceptors.ts
 │   │   │   │   │   └── token-refresh.ts
-│   │   │   │   ├── client-utils.ts
-│   │   │   │   ├── index.ts
-│   │   │   │   ├── token-store.ts
+│   │   │   │   ├── client-utils.ts             # TokenRefreshManager + helpers
+│   │   │   │   ├── index.ts                    # Public surface: fetchClient, axiosClient, toSearchParams
+│   │   │   │   ├── token-store.ts              # secureStorageTokenStore (inert in cookie-mode)
 │   │   │   │   └── README.md
 │   │   │   └── index.ts
 │   │   └── validations/

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-secure-storage": "^1.3.2",
     "redux": "^5.0.1",
     "redux-persist": "^6.0.0",
+    "server-only": "^0.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/lib/config/api-url.ts
+++ b/src/lib/config/api-url.ts
@@ -1,0 +1,34 @@
+import { env } from '@/lib/env';
+import { logger } from '@/lib/logger';
+
+import { API_PREFIX } from './constants';
+
+const TRAILING_API_PREFIX = /\/api\/v\d+\/?$/;
+
+/**
+ * Compose the API base URL the HTTP clients should hit.
+ *
+ * `NEXT_PUBLIC_API_URL` is the **bare origin** (e.g. `https://api.example.com`).
+ * If an operator accidentally includes the `/api/v{n}` suffix, strip it and
+ * warn — keeps the request path correct without silently double-prefixing.
+ *
+ * Lives outside `constants.ts` because `next.config.ts` imports from
+ * `constants.ts` at config-load time, before path aliases are wired up.
+ */
+export function getApiBaseUrl(): string {
+  const raw = (env.NEXT_PUBLIC_API_URL ?? '').trim();
+  if (!raw) return API_PREFIX;
+
+  const origin = raw.replace(/\/$/, '');
+
+  if (TRAILING_API_PREFIX.test(origin)) {
+    const cleaned = origin.replace(TRAILING_API_PREFIX, '');
+    logger.warn(
+      { provided: raw, used: `${cleaned}${API_PREFIX}` },
+      'NEXT_PUBLIC_API_URL should be the bare origin; the /api/v{n} suffix is added internally.',
+    );
+    return `${cleaned}${API_PREFIX}`;
+  }
+
+  return `${origin}${API_PREFIX}`;
+}

--- a/src/lib/config/app-apis.ts
+++ b/src/lib/config/app-apis.ts
@@ -1,8 +1,18 @@
-import { API_PREFIX } from './constants';
-
+/**
+ * Backend API endpoint paths.
+ *
+ * Paths are **relative to the API base** (which already includes `/api/v{n}`
+ * via `getApiBaseUrl()`), so we don't repeat the version prefix here.
+ *
+ * Mirrors `AppPaths.auth` in the NestJS starter — keep in sync when the
+ * backend renames routes.
+ */
 export const AppApis = {
   auth: {
-    base: `${API_PREFIX}/auth`,
-    refreshToken: `${API_PREFIX}/auth/refresh-token`,
+    login: '/auth/login',
+    logout: '/auth/logout',
+    refresh: '/auth/refresh',
+    me: '/auth/me',
+    capabilities: '/auth/login/capabilities',
   },
 } as const;

--- a/src/lib/config/constants.ts
+++ b/src/lib/config/constants.ts
@@ -1,12 +1,27 @@
 import { Environment } from '../enums';
 
-export const API_VERSION = 'v1';
-export const BASE_API_PREFIX = '/api';
-export const API_PREFIX = `${BASE_API_PREFIX}/${API_VERSION}`;
+/**
+ * URI version prefix the backend mounts under (`/api/v{n}`).
+ *
+ * Owned by the frontend because the backend uses Nest URI versioning — the
+ * version is part of the **contract**, not the deployment. Bumping it here is
+ * a single-line change; pushing it into env means every environment has to be
+ * touched in lockstep.
+ *
+ * Use `getApiBaseUrl()` from `./api-url` to compose the full base URL.
+ */
+export const API_PREFIX = '/api/v1';
+
 export const API_RESPONSE_DATA_KEY = 'data';
+
+/**
+ * Cookie-mode auth is the default: backend sets HttpOnly access/refresh
+ * cookies on login and reads them via Passport extractors. Flip to `true`
+ * to switch to bearer-token mode — the token store + Authorization header
+ * plumbing is already in place but inert by default.
+ */
 export const SAVE_AUTH_TOKENS = false;
 
-// Environment checks
 export const isProduction = process.env.NODE_ENV === Environment.PRODUCTION;
 export const isDevelopment = process.env.NODE_ENV === Environment.DEVELOPMENT;
 export const isTest = process.env.NODE_ENV === Environment.TEST;

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,3 +1,4 @@
+export * from './api-url';
 export * from './app-apis';
 export * from './app-locales';
 export * from './app-paths';

--- a/src/lib/env/schema.ts
+++ b/src/lib/env/schema.ts
@@ -19,7 +19,11 @@ export const envSchema = z.object({
 
   NEXT_PUBLIC_API_URL: z
     .preprocess(emptyStringToUndefined, z.url().optional())
-    .describe('Base URL for the backing API. Empty means relative/proxied requests.'),
+    .describe(
+      'Bare origin of the backing API (e.g. `https://api.example.com`). ' +
+        'The `/api/v{n}` URI-version prefix is appended internally — do not include it here. ' +
+        'Empty means relative/proxied requests under the same origin.',
+    ),
 
   NEXT_PUBLIC_APP_URL: z
     .preprocess(emptyStringToUndefined, z.url().default('http://localhost:3000'))

--- a/src/lib/errors/api-exception.ts
+++ b/src/lib/errors/api-exception.ts
@@ -7,6 +7,7 @@ type ApiExceptionOptions = {
   errors?: Record<string, string>[];
   data?: Record<string, unknown>;
   path?: string;
+  requestId?: string;
   stack?: string;
 };
 
@@ -16,14 +17,25 @@ export class ApiException extends Error {
   errors?: Record<string, string>[];
   data?: Record<string, unknown>;
   path?: string;
+  requestId?: string;
 
-  constructor({ status, message, code, errors, data, path, stack }: ApiExceptionOptions) {
+  constructor({
+    status,
+    message,
+    code,
+    errors,
+    data,
+    path,
+    requestId,
+    stack,
+  }: ApiExceptionOptions) {
     super(message);
     this.status = status;
     this.code = code;
     this.errors = errors;
     this.data = data;
     this.path = path;
+    this.requestId = requestId;
 
     if (stack) {
       this.stack = stack;
@@ -41,6 +53,7 @@ export class ApiException extends Error {
       errors: body.errors,
       data: body.data,
       path: body.path,
+      requestId: body.requestId,
     });
   }
 

--- a/src/lib/utils/http/README.md
+++ b/src/lib/utils/http/README.md
@@ -1,977 +1,599 @@
-# HTTP Client Documentation
+# HTTP Clients
 
-Complete guide for making API requests in this Next.js application using our custom HTTP clients.
+**TL;DR** — Two interchangeable HTTP clients (`fetchClient`, `axiosClient`) that talk to the NestJS-starter backend out of the box. Cookie-mode auth by default. SSR-safe. Errors come back as a typed `ApiException`, never thrown. Every request is correlated with the backend via `X-Request-Id`. Pass typed query objects via `{ params }` — no `URLSearchParams` boilerplate.
 
-> **💡 Note:** During project setup, you can choose which HTTP client(s) to keep. Run `yarn setup` to configure your preferred client (Axios, Fetch, both, or remove all).
+```
+src/lib/utils/http/
+├─ shared/          ← runtime detection, cookie injection, request-id, error parsing, params serialiser
+├─ fetch-client/    ← Fetch adapter on the shared foundation
+├─ axios-client/    ← Axios adapter on the shared foundation (same surface)
+├─ client-utils.ts  ← TokenRefreshManager + helpers
+├─ token-store.ts   ← secureStorageTokenStore (inert in cookie-mode)
+└─ index.ts         ← public surface: fetchClient, axiosClient, toSearchParams
+```
+
+Feature code imports from `@/lib/utils/http` only. The `shared/` layer is internal — its concerns leak through `fetchClient` / `axiosClient`, not separate imports.
+
+---
 
 ## Table of Contents
 
-- [Quick Start](#quick-start)
-- [Available Clients](#available-clients)
-- [Basic Usage](#basic-usage)
-- [Advanced Usage](#advanced-usage)
-- [Error Handling](#error-handling)
+- [Quick start](#quick-start)
+- [Configuration](#configuration)
+- [Choosing a client](#choosing-a-client)
+- [Making requests](#making-requests)
+- [Typed queries and pagination](#typed-queries-and-pagination)
+- [Error handling](#error-handling)
 - [Authentication](#authentication)
-- [Custom Client Configuration](#custom-client-configuration)
-- [API Reference](#api-reference)
+- [Server-side rendering](#server-side-rendering)
+- [Request correlation (X-Request-Id)](#request-correlation-x-request-id)
+- [Custom clients](#custom-clients)
+- [API reference](#api-reference)
+- [Best practices](#best-practices)
+- [Troubleshooting](#troubleshooting)
+- [Related docs](#related-docs)
 
 ---
 
-## Quick Start
+## Quick start
 
-```typescript
+```ts
 import { fetchClient } from '@/lib/utils/http';
 
-async function getUsers() {
-  const result = await fetchClient.get('/users');
-
-  if (result.isLeft()) {
-    console.error(result.value.message);
-    return;
-  }
-
-  const users = result.value;
-  console.log(users);
-}
-```
-
----
-
-## Available Clients
-
-### 1. `fetchClient` (Recommended)
-
-**Native Fetch API** - Zero dependencies, works everywhere
-
-```typescript
-import { fetchClient } from '@/lib/utils/http';
-```
-
-**When to use:**
-
-- ✅ Server Components
-- ✅ Client Components
-- ✅ Edge Runtime
-- ✅ API Routes
-- ✅ Server Actions
-- ✅ Middleware
-
-**Bundle Size:** 0KB (native browser API)
-
-### 2. `axiosClient`
-
-**Axios-based** - For legacy code or specific Axios features
-
-```typescript
-import { axiosClient } from '@/lib/utils/http';
-```
-
-**When to use:**
-
-- ✅ Node.js specific features
-- ✅ Legacy code migration
-- ✅ Advanced request/response transformations
-
-**Bundle Size:** ~30KB
-
----
-
-## Basic Usage
-
-### GET Request
-
-```typescript
-import { fetchClient } from '@/lib/utils/http';
-
-async function fetchUser(id: string) {
-  const result = await fetchClient.get(`/users/${id}`);
-
-  if (result.isRight()) {
-    const user = result.value;
-    return user;
-  }
-
-  const error = result.value;
-  console.error(error.message);
-  return null;
-}
-```
-
-### POST Request
-
-```typescript
-async function createUser(userData: CreateUserDto) {
-  const result = await fetchClient.post('/users', userData);
-
-  if (result.isRight()) {
-    console.log('User created:', result.value);
-  } else {
-    console.error('Failed:', result.value.message);
-  }
-}
-```
-
-### PUT Request
-
-```typescript
-async function updateUser(id: string, data: UpdateUserDto) {
-  const result = await fetchClient.put(`/users/${id}`, data);
-
-  return result.isRight() ? result.value : null;
-}
-```
-
-### PATCH Request
-
-```typescript
-async function partialUpdate(id: string, data: Partial<User>) {
-  const result = await fetchClient.patch(`/users/${id}`, data);
-
-  return result;
-}
-```
-
-### DELETE Request
-
-```typescript
-async function deleteUser(id: string) {
-  const result = await fetchClient.delete(`/users/${id}`);
-
-  if (result.isRight()) {
-    console.log('User deleted successfully');
-  }
-}
-```
-
----
-
-## Advanced Usage
-
-### Custom Headers
-
-```typescript
-const result = await fetchClient.get('/users', {
-  headers: {
-    'X-Custom-Header': 'value',
-  },
-});
-```
-
-### Query Parameters
-
-```typescript
-const params = new URLSearchParams({
-  page: '1',
-  limit: '10',
-  sort: 'createdAt',
-});
-
-const result = await fetchClient.get(`/users?${params}`);
-```
-
-### Paginated Requests
-
-```typescript
-import { PaginatedApiResponse } from '@/types';
-
-async function fetchUsers(page: number, pageSize: number) {
-  const params = new URLSearchParams({
-    page: page.toString(),
-    pageSize: pageSize.toString(),
-  });
-
-  const result = await fetchClient.get<PaginatedApiResponse<User>>(`/users?${params}`);
-
-  if (result.isRight()) {
-    const { items, meta } = result.value;
-
-    console.log('Users:', items);
-    console.log('Total:', meta.totalItems);
-    console.log('Current Page:', meta.currentPage);
-    console.log('Total Pages:', meta.totalPages);
-
-    return result.value;
-  }
-
-  return null;
-}
-```
-
-#### React Pagination Example
-
-```typescript
-'use client';
-
-import { fetchClient } from '@/lib/utils/http';
-import { PaginatedApiResponse } from '@/types';
-import { useState, useEffect } from 'react';
-
-export function PaginatedUserList() {
-  const [data, setData] = useState<PaginatedApiResponse<User> | null>(null);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [loading, setLoading] = useState(false);
-  const pageSize = 10;
-
-  useEffect(() => {
-    async function loadUsers() {
-      setLoading(true);
-      const params = new URLSearchParams({
-        page: currentPage.toString(),
-        pageSize: pageSize.toString(),
-      });
-
-      const result = await fetchClient.get<PaginatedApiResponse<User>>(
-        `/users?${params}`
-      );
-
-      if (result.isRight()) {
-        setData(result.value);
-      }
-      setLoading(false);
-    }
-
-    loadUsers();
-  }, [currentPage]);
-
-  if (!data) return <div>Loading...</div>;
-
-  return (
-    <div>
-      <ul>
-        {data.items.map(user => (
-          <li key={user.id}>{user.name}</li>
-        ))}
-      </ul>
-
-      <div className="pagination">
-        <button
-          onClick={() => setCurrentPage(p => p - 1)}
-          disabled={currentPage === 1}
-        >
-          Previous
-        </button>
-
-        <span>
-          Page {data.meta.currentPage} of {data.meta.totalPages}
-        </span>
-
-        <button
-          onClick={() => setCurrentPage(p => p + 1)}
-          disabled={currentPage === data.meta.totalPages}
-        >
-          Next
-        </button>
-
-        <span>Total: {data.meta.totalItems} items</span>
-      </div>
-    </div>
-  );
-}
-```
-
-#### Server Component Pagination
-
-```typescript
-import { fetchClient } from '@/lib/utils/http';
-import { PaginatedApiResponse } from '@/types';
-
-interface UsersPageProps {
-  searchParams: { page?: string };
-}
-
-export default async function UsersPage({ searchParams }: UsersPageProps) {
-  const page = Number(searchParams.page) || 1;
-  const pageSize = 20;
-
-  const params = new URLSearchParams({
-    page: page.toString(),
-    pageSize: pageSize.toString(),
-  });
-
-  const result = await fetchClient.get<PaginatedApiResponse<User>>(
-    `/users?${params}`
-  );
-
-  if (result.isLeft()) {
-    return <div>Error loading users</div>;
-  }
-
-  const { items, meta } = result.value;
-
-  return (
-    <div>
-      <h1>Users ({meta.totalItems})</h1>
-
-      <ul>
-        {items.map(user => (
-          <li key={user.id}>{user.name}</li>
-        ))}
-      </ul>
-
-      <div>
-        {meta.currentPage > 1 && (
-          <a href={`/users?page=${meta.currentPage - 1}`}>Previous</a>
-        )}
-
-        <span>Page {meta.currentPage} of {meta.totalPages}</span>
-
-        {meta.currentPage < meta.totalPages && (
-          <a href={`/users?page=${meta.currentPage + 1}`}>Next</a>
-        )}
-      </div>
-    </div>
-  );
-}
-```
-
-### Request Options (Fetch Client)
-
-```typescript
-const result = await fetchClient.post('/users', data, {
-  cache: 'no-cache',
-  next: { revalidate: 3600 },
-  signal: AbortSignal.timeout(5000),
-});
-```
-
-### Skip Data Extraction
-
-By default, clients extract `data.data` from responses. To get raw response:
-
-```typescript
-const result = await fetchClient.get('/users', undefined, null);
-```
-
-### Custom Data Key
-
-```typescript
-const result = await fetchClient.get('/users', undefined, 'items');
-```
-
----
-
-## Error Handling
-
-### Using Either Pattern
-
-```typescript
-const result = await fetchClient.get('/users');
+const result = await fetchClient.get<User>('/users/123');
 
 if (result.isLeft()) {
-  const error = result.value;
-  console.error({
-    status: error.status,
-    message: error.message,
-    errors: error.errors,
-  });
-  return;
+  // result.value is an ApiException
+  return showError(result.value);
 }
 
-const users = result.value;
+const user = result.value; // typed as User
 ```
 
-### Using fold() Method
+Same call in a Server Component — no extra wiring, cookies forward automatically:
 
-```typescript
-const result = await fetchClient.get<User[]>('/users');
+```ts
+// app/[locale]/profile/page.tsx
+import { fetchClient } from '@/lib/utils/http';
 
-result.fold(
-  (error) => {
-    console.error('Error:', error.message);
+export default async function ProfilePage() {
+  const result = await fetchClient.get<User>('/auth/me');
+  if (result.isLeft()) return <div>Not signed in</div>;
+  return <Profile user={result.value} />;
+}
+```
+
+---
+
+## Configuration
+
+### Environment
+
+```env
+NEXT_PUBLIC_API_URL=https://api.example.com
+```
+
+`NEXT_PUBLIC_API_URL` is the **bare origin** — no `/api/v{n}` suffix. The version prefix is owned by the frontend and appended internally via `getApiBaseUrl()`:
+
+- Empty → relative/proxied requests under the same origin.
+- Includes `/api/v1` by accident → stripped with a logger warning (no double-prefix).
+- Bumping API version → one-line change in `src/lib/config/constants.ts`, no env churn across environments.
+
+The full env schema lives in `src/lib/env/schema.ts`.
+
+### Constants
+
+| Constant | File | Default | Meaning |
+|---|---|---|---|
+| `API_PREFIX` | `src/lib/config/constants.ts` | `'/api/v1'` | URI version segment appended to `NEXT_PUBLIC_API_URL` |
+| `SAVE_AUTH_TOKENS` | `src/lib/config/constants.ts` | `false` | Cookie-mode auth (default) vs bearer-mode |
+| `API_RESPONSE_DATA_KEY` | `src/lib/config/constants.ts` | `'data'` | Key auto-unwrapped from the success envelope; override per-call via `dataKey` |
+
+### Endpoint paths
+
+`src/lib/config/app-apis.ts` mirrors the backend's `AppPaths.auth`. Paths are relative to the API base — they don't repeat `/api/v1`. Keep this file in sync when the backend renames a route:
+
+```ts
+export const AppApis = {
+  auth: {
+    login: '/auth/login',
+    logout: '/auth/logout',
+    refresh: '/auth/refresh',
+    me: '/auth/me',
+    capabilities: '/auth/login/capabilities',
   },
-  (users) => {
-    console.log('Success:', users);
-  },
+} as const;
+```
+
+---
+
+## Choosing a client
+
+| | `fetchClient` (recommended) | `axiosClient` |
+|---|---|---|
+| Runtime | Native Fetch | Axios |
+| Bundle | 0 KB | ~30 KB |
+| Works in | Browser, RSC, Server Actions, Route Handlers, `proxy.ts`, Edge | Same — except not Edge |
+| When to reach for | Default for everything | Axios-specific features (cancellation tokens, advanced transforms) |
+
+Both clients share **identical** contracts: same return type, same `_skipAuthInterceptor` escape hatch, same `params` option, same auth/cookie/request-id behaviour, same `ApiException` errors. **Don't mix them in the same feature** — pick one and stick to it.
+
+```ts
+import { fetchClient } from '@/lib/utils/http';
+import { axiosClient } from '@/lib/utils/http'; // when you need it
+```
+
+---
+
+## Making requests
+
+### Verbs
+
+```ts
+fetchClient.get<T>(url, options?, dataKey?)
+fetchClient.post<T>(url, data?, options?, dataKey?)
+fetchClient.put<T>(url, data?, options?, dataKey?)
+fetchClient.patch<T>(url, data?, options?, dataKey?)
+fetchClient.delete<T>(url, options?, dataKey?)
+```
+
+Each returns `ResultAsync<T>` — alias for `Promise<Either<ApiException, T>>`. **Nothing ever throws.** Network failures, 5xx, validation errors, all 4xx — every failure mode lands in the left side of the result.
+
+### Handling the result
+
+Three patterns, all valid:
+
+```ts
+const result = await fetchClient.get<User>('/users/123');
+
+// 1. Guard + value (most readable)
+if (result.isLeft()) {
+  return handleError(result.value);
+}
+const user = result.value;
+
+// 2. fold — pattern match into a single value
+const greeting = result.fold(
+  (err) => `Error: ${err.message}`,
+  (user) => `Hello, ${user.name}`,
 );
-```
 
-### Handling Validation Errors
-
-ApiException provides utility methods for working with validation errors:
-
-```typescript
-const result = await fetchClient.post('/users', invalidData);
-
-if (result.isLeft()) {
-  const error = result.value;
-
-  // Check if specific field has error
-  if (error.containsKey('email')) {
-    console.log('Email error:', error.getErrorMessage('email'));
-  }
-
-  // Get error message for field or fallback to general message
-  const emailError = error.getErrorMessageIfExists('email');
-
-  // Get all field errors as object
-  const fieldErrors = error.getFieldErrors();
-  // { email: 'Invalid email format', password: 'Too short' }
-
-  Object.entries(fieldErrors).forEach(([field, message]) => {
-    console.log(`${field}: ${message}`);
-  });
+// 3. isRight — when you only care about the success path
+if (result.isRight()) {
+  setUser(result.value);
 }
 ```
 
-#### Using with React Forms
+See [Error handling](#error-handling) for what `ApiException` exposes (validation helpers, field errors, `requestId` for tracing).
 
-```typescript
-'use client';
+### Response unwrapping
 
-import { fetchClient } from '@/lib/utils/http';
-import { useState } from 'react';
+The backend wraps every success in `{ status, path, message, data, timestamp }`. By default, the clients return the inner `data` field — that's what `dataKey = 'data'` controls.
 
-export function UserForm() {
-  const [errors, setErrors] = useState<Record<string, string>>({});
+```ts
+const result = await fetchClient.get<User>('/users/123');
+// result.value === envelope.data — typed as User
+```
 
-  async function handleSubmit(data: FormData) {
-    const result = await fetchClient.post('/users', data);
+To get the whole envelope, pass `null`:
 
-    if (result.isLeft()) {
-      const error = result.value;
+```ts
+const result = await fetchClient.get<ApiResponse<User>>('/users/123', undefined, null);
+// result.value.timestamp, result.value.path, etc.
+```
 
-      // Set all validation errors at once
-      setErrors(error.getFieldErrors());
-    } else {
-      setErrors({});
-      console.log('Success!');
-    }
-  }
+To unwrap a different key:
 
-  return (
-    <form onSubmit={handleSubmit}>
-      <input name="email" />
-      {errors.email && <span className="error">{errors.email}</span>}
+```ts
+const result = await fetchClient.get<User[]>('/users', undefined, 'items');
+```
 
-      <input name="password" />
-      {errors.password && <span className="error">{errors.password}</span>}
-    </form>
-  );
+---
+
+## Typed queries and pagination
+
+Both clients accept a `params` option that takes a **typed query object** and serialises it for you. No string concat, no inline `URLSearchParams` boilerplate.
+
+The shared serialiser (`toSearchParams`) skips `undefined`/`null`/`''` so the backend's defaults (`page=1`, `size=10`, etc.) stay implicit, and it repeats keys for arrays (`tag=a&tag=b`). **Both clients use the same serialiser** — axios's default is overridden so query strings are byte-identical regardless of which client made the call.
+
+### Define a query type per endpoint
+
+Extend `BaseQueryParams` for offset pagination or `BaseCursorQueryParams` for cursor pagination, then add endpoint-specific filters:
+
+```ts
+// src/features/users/types/users-query.types.ts
+import type { BaseQueryParams } from '@/types';
+
+export interface UsersQuery extends BaseQueryParams {
+  status?: 'active' | 'invited' | 'disabled';
+  roleId?: string;
 }
 ```
 
-### Using in React Components
+`BaseQueryParams` already mirrors the backend's `BaseQueryDto` exactly (`page`, `size`, `search`, `sort`, `order`) — no field-name drift.
 
-```typescript
+### Call the endpoint with a single typed argument
+
+```ts
+import { fetchClient } from '@/lib/utils/http';
+import type { PaginatedApiResponse } from '@/types';
+
+export async function fetchUsers(query: UsersQuery) {
+  return fetchClient.get<PaginatedApiResponse<User>>('/users', { params: query });
+}
+
+// Call site — structured object, not positional args:
+await fetchUsers({ page: 2, size: 20, status: 'active' });
+```
+
+Mix `params` with other transport options freely:
+
+```ts
+await fetchClient.get<PaginatedApiResponse<User>>('/users', {
+  params: { page: 1 },
+  signal: AbortSignal.timeout(5000),
+  cache: 'no-store',
+});
+```
+
+### `satisfies` for inline queries
+
+When you don't want to declare a `const query: UsersQuery = ...` separately, use TypeScript's `satisfies` operator to check the literal against the query interface without widening its type:
+
+```ts
+const result = await fetchClient.get<PaginatedApiResponse<User>>('/users', {
+  params: { page: 1, size: 20, status: 'active' } satisfies UsersQuery,
+});
+```
+
+This catches typos in field names at compile time without forcing you to invent a variable just to type-check it.
+
+### Offset pagination
+
+```ts
+const result = await fetchClient.get<PaginatedApiResponse<User>>('/users', {
+  params: { page: 1, size: 20 } satisfies UsersQuery,
+});
+
+if (result.isRight()) {
+  const { items, meta } = result.value;
+  // meta: { totalItems, totalPages, currentPage, pageSize, sortBy, order }
+}
+```
+
+### Cursor pagination
+
+```ts
+import type { BaseCursorQueryParams, CursorPaginatedApiResponse } from '@/types';
+
+interface FeedQuery extends BaseCursorQueryParams {
+  authorId?: string;
+}
+
+const result = await fetchClient.get<CursorPaginatedApiResponse<Post>>('/feed', {
+  params: { cursor, size: 20 } satisfies FeedQuery,
+});
+
+if (result.isRight()) {
+  const { items, meta } = result.value;
+  // meta: { nextCursor, prevCursor, hasMore, pageSize, sortBy, order }
+}
+```
+
+### React infinite-scroll example
+
+```tsx
 'use client';
 
+import { useEffect, useState } from 'react';
 import { fetchClient } from '@/lib/utils/http';
-import { useState, useEffect } from 'react';
+import type { CursorPaginatedApiResponse } from '@/types';
 
-export function UserList() {
-  const [users, setUsers] = useState<User[]>([]);
-  const [error, setError] = useState<string | null>(null);
+export function PostFeed() {
+  const [items, setItems] = useState<Post[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+
+  async function loadMore() {
+    const result = await fetchClient.get<CursorPaginatedApiResponse<Post>>('/feed', {
+      params: { cursor: cursor ?? undefined, size: 20 } satisfies FeedQuery,
+    });
+    if (result.isLeft()) return;
+    setItems((prev) => [...prev, ...result.value.items]);
+    setCursor(result.value.meta.nextCursor);
+    setHasMore(result.value.meta.hasMore);
+  }
 
   useEffect(() => {
-    async function loadUsers() {
-      const result = await fetchClient.get<User[]>('/users');
-
-      if (result.isRight()) {
-        setUsers(result.value);
-      } else {
-        setError(result.value.message);
-      }
-    }
-
-    loadUsers();
+    loadMore();
   }, []);
 
-  if (error) return <div>Error: {error}</div>;
-
   return (
-    <ul>
-      {users.map(user => <li key={user.id}>{user.name}</li>)}
-    </ul>
+    <>
+      {items.map((p) => <Post key={p.id} {...p} />)}
+      {hasMore && <button onClick={loadMore}>Load more</button>}
+    </>
   );
 }
 ```
 
-### Using in Server Components
+### Raw `toSearchParams`
 
-```typescript
-import { fetchClient } from '@/lib/utils/http';
+Exported for cases where you need a query string **without** making a request — building an `href`, redirect target, cache key:
 
-export default async function UsersPage() {
-  const result = await fetchClient.get<User[]>('/users');
+```ts
+import { toSearchParams } from '@/lib/utils/http';
 
-  if (result.isLeft()) {
-    return <div>Error: {result.value.message}</div>;
-  }
+const href = `/users?${toSearchParams<UsersQuery>({ status: 'active' })}`;
+```
 
-  const users = result.value;
+For actual requests, prefer `{ params }` — it's terser and the client handles the edge cases (`?` vs `&`, empty serialisation) for you.
 
-  return (
-    <ul>
-      {users.map(user => <li key={user.id}>{user.name}</li>)}
-    </ul>
-  );
+---
+
+## Error handling
+
+All errors are `ApiException` instances on the left side of the result. The backend's `GlobalExceptionFilter` produces a structured envelope and `parseApiError` lifts every field into typed properties.
+
+### Field-level validation errors
+
+Backend's exception filter returns a structured `errors` array. `ApiException` exposes helpers:
+
+```ts
+const result = await fetchClient.post('/users', invalidPayload);
+
+if (result.isLeft()) {
+  const err = result.value;
+
+  err.containsKey('email');              // boolean
+  err.getErrorMessage('email');          // 'Invalid format' | undefined
+  err.getErrorMessageIfExists('email');  // 'Invalid format' | err.message
+  err.getFieldErrors();                  // { email: 'Invalid format', ... }
 }
 ```
+
+For forms, `getFieldErrors()` is the one-call setter you want:
+
+```ts
+const result = await fetchClient.post('/users', data);
+if (result.isLeft()) {
+  setFieldErrors(result.value.getFieldErrors());
+}
+```
+
+See the [`ApiException` reference](#apiexception) for the full surface.
 
 ---
 
 ## Authentication
 
-### Automatic Token Management
+### Cookie-mode (default)
 
-Both clients automatically:
+`SAVE_AUTH_TOKENS = false`. The backend sets HttpOnly `access` and `refresh` cookies on login, and reads them via Passport's cookie + Bearer extractor chain. The frontend:
 
-- ✅ Add authentication headers
-- ✅ Refresh expired tokens
-- ✅ Retry failed requests with new tokens
-- ✅ Redirect to login on auth failure
+- Sends every request with `credentials: 'include'` (browser cookie jar) or an injected `Cookie` header (server).
+- Never reads tokens from the response body or stores them client-side.
+- Token refresh hits `POST /auth/refresh` with `credentials: 'include'` — the `refresh` cookie carries the token; no `Authorization` header.
 
-### Token Storage
+Safer default: tokens never touch JavaScript-accessible storage, so XSS can't exfiltrate them.
 
-Tokens are stored via `secureStorageTokenStore`:
+### Bearer-mode
 
-- **Browser:** localStorage (encrypted)
-- **Server:** Memory (request scoped)
+Flip `SAVE_AUTH_TOKENS = true`. The clients then:
 
-### Manual Token Refresh
+- Persist `accessToken` / `refreshToken` to `react-secure-storage` (wrapped by `src/services/storage/secure-storage.service.ts`).
+- Attach `Authorization: Bearer <accessToken>` to every request.
+- Send the stored refresh token as Bearer when calling `/auth/refresh`.
 
-```typescript
-import { fetchClient } from '@/lib/utils/http';
+Both modes hit the **same** backend endpoint; only the carrier differs.
 
-const result = await fetchClient.post('/auth/refresh');
+### Automatic refresh on 401
+
+Both clients debounce a single refresh per token-expiry window and replay the failed request once the new token is in hand. Failure (or hitting `MAX_ATTEMPTS = 3` within `COOLDOWN_MS = 1000`) clears local state and triggers `onUnauthorized` — defaulted to redirect to `/login?redirectTo=<current>`.
+
+### Skip auth on a single call
+
+```ts
+await fetchClient.get('/public/data', { _skipAuthInterceptor: true });
+await axiosClient.get('/public/data', { _skipAuthInterceptor: true });
 ```
-
-### Skip Auth for Public Endpoints
-
-```typescript
-const result = await fetchClient.get('/public/data', {
-  _skipAuthInterceptor: true,
-});
-```
-
-### Cookie-based Authentication
-
-Both clients send cookies automatically:
-
-- `fetchClient`: via `credentials: 'include'`
-- `axiosClient`: via `withCredentials: true`
 
 ---
 
-## Custom Client Configuration
+## Server-side rendering
 
-### Create Custom Fetch Client
+`credentials: 'include'` (fetch) and `withCredentials: true` (axios) are **browser-only**. Node has no cookie jar, so without explicit forwarding the backend's HttpOnly cookies never reach it from a Server Component, Server Action, or Route Handler.
 
-```typescript
-import { createFetchClient } from '@/lib/utils/http';
-import { secureStorageTokenStore } from '@/lib/utils/http/token-store';
+Both clients handle this transparently. The shared `getCookieHeaderForRequest()` helper:
 
-const customClient = createFetchClient({
-  baseURL: 'https://api.example.com',
+1. Returns `undefined` in the browser (jar handles it).
+2. On the server, dynamically imports a `server-only` module that reads `next/headers` and serialises the incoming request's cookies into a `Cookie` header.
+
+The dynamic import keeps `next/headers` out of the client bundle entirely. **Feature code never imports `server-cookies` directly** — only the runtime-aware `cookie-injection` does, and only on the server.
+
+```ts
+// Same import, same call, both contexts:
+import { fetchClient } from '@/lib/utils/http';
+
+// In a client component:
+'use client';
+const r = await fetchClient.get('/auth/me'); // browser cookie jar
+
+// In a Server Component:
+const r = await fetchClient.get('/auth/me'); // next/headers → Cookie header
+```
+
+---
+
+## Request correlation (X-Request-Id)
+
+Every outgoing request is stamped with a fresh UUID matching the backend's `REQUEST_ID_PATTERN` (`^[A-Za-z0-9_-]{1,128}$`). Backend behaviour:
+
+- Accepts client-supplied IDs that match the pattern → echoes the same ID on the response.
+- Rejects malformed input → generates its own, echoes that.
+- Always sets `X-Request-Id` on the response (success header **and** error envelope `requestId` field).
+- Exposes the header via CORS so cross-origin browser fetches can read it.
+
+The clients read the response header (or `body.requestId` on errors), stash it on `ApiException.requestId`, and make it available to your error handlers / Sentry / logger:
+
+```ts
+const result = await fetchClient.get('/users/123');
+if (result.isLeft()) {
+  logger.error({ requestId: result.value.requestId }, 'lookup failed');
+  // Now grep both browser AND backend pino logs for the same requestId.
+}
+```
+
+### Override per call
+
+If you already have an upstream trace ID (e.g. SSR passing a Vercel request ID through), pass it explicitly:
+
+```ts
+await fetchClient.get('/users', {
+  headers: { 'X-Request-Id': vercelRequestId },
+});
+```
+
+The interceptor only generates a fresh ID when none was provided or the provided value doesn't match the pattern.
+
+---
+
+## Custom clients
+
+Use `createFetchClient` / `createAxiosClient` to point at a different upstream (a second backend, a third-party API) while keeping all the shared behaviour:
+
+```ts
+import { createFetchClient, secureStorageTokenStore } from '@/lib/utils/http';
+
+const upstream = createFetchClient({
+  baseURL: 'https://other-service.internal',
   tokenStore: secureStorageTokenStore,
   cache: 'force-cache',
-  defaultOptions: {
-    headers: {
-      'X-API-Version': 'v2',
-    },
-  },
-  onUnauthorized: () => {
-    console.log('Auth failed');
-    window.location.href = '/login';
-  },
+  defaultOptions: { headers: { 'X-Service': 'upstream' } },
+  onUnauthorized: () => { window.location.href = '/login'; },
 });
 ```
 
-### Create Custom Axios Client
+The `createAxiosClient` shape mirrors this; pass `defaultHeaders` instead of `defaultOptions.headers`.
 
-```typescript
-import { createAxiosClient } from '@/lib/utils/http';
-import { secureStorageTokenStore } from '@/lib/utils/http/token-store';
-
-const customClient = createAxiosClient({
-  baseURL: 'https://api.example.com',
-  tokenStore: secureStorageTokenStore,
-  onUnauthorized: () => {
-    window.location.href = '/login';
-  },
-});
-```
-
-### Custom Token Store
-
-```typescript
-import { TokenStore } from '@/types';
-
-const customTokenStore: TokenStore = {
-  async getAccessToken() {
-    return sessionStorage.getItem('access_token');
-  },
-  async saveAccessToken(token: string) {
-    sessionStorage.setItem('access_token', token);
-  },
-  async getRefreshToken() {
-    return sessionStorage.getItem('refresh_token');
-  },
-  async saveRefreshToken(token: string) {
-    sessionStorage.setItem('refresh_token', token);
-  },
-  async clear() {
-    sessionStorage.clear();
-  },
-};
-
-const client = createFetchClient({
-  tokenStore: customTokenStore,
-});
-```
+For a custom token store, implement the `TokenStore` interface (5 methods: `getAccessToken`, `saveAccessToken`, `getRefreshToken`, `saveRefreshToken`, `clear`) and pass it in. See `src/lib/utils/http/token-store.ts` for the default `react-secure-storage` implementation as a reference.
 
 ---
 
-## API Reference
+## API reference
 
-### Client Methods
+### Client methods
 
-#### `get<T>(url, options?, dataKey?)`
+| Method | Signature |
+|---|---|
+| `get<T>` | `(url, options?, dataKey?) => ResultAsync<T>` |
+| `post<T>` | `(url, data?, options?, dataKey?) => ResultAsync<T>` |
+| `put<T>` | `(url, data?, options?, dataKey?) => ResultAsync<T>` |
+| `patch<T>` | `(url, data?, options?, dataKey?) => ResultAsync<T>` |
+| `delete<T>` | `(url, options?, dataKey?) => ResultAsync<T>` |
 
-**Parameters:**
+- `options` is `ExtendedRequestInit` for fetch and `AxiosRequestConfig` for axios. Both accept `params?: Record<string, unknown>` and `_skipAuthInterceptor?: boolean` on top of the standard fields.
+- `dataKey` defaults to `'data'`. Pass `null` to skip unwrapping (returns the whole envelope). Pass a string to unwrap a different key.
 
-- `url` - Request URL (relative to baseURL)
-- `options` - Request configuration (optional)
-- `dataKey` - Key to extract from response (default: 'data')
+### `Either<L, R>` methods
 
-**Returns:** `Promise<Either<ApiException, T>>`
+| Method | Returns |
+|---|---|
+| `isLeft()` | `true` when the result is an error |
+| `isRight()` | `true` when the result is a success |
+| `value` | The error (left) or the data (right) |
+| `fold(onLeft, onRight)` | Pattern-match into a single value |
 
-#### `post<T>(url, data?, options?, dataKey?)`
+### `ApiException`
 
-**Parameters:**
+| Field / method | Type | Notes |
+|---|---|---|
+| `status` | `number` | HTTP status. `0` for network failures. |
+| `message` | `string` | Human-readable summary from the backend. |
+| `code` | `string \| undefined` | Machine-readable code (e.g. `USER_NOT_FOUND`). |
+| `errors` | `Array<Record<string, string>>` | Field-level validation errors. |
+| `data` | `Record<string, unknown>` | Arbitrary extra context. |
+| `path` | `string \| undefined` | Request path the backend logged. |
+| `requestId` | `string \| undefined` | Correlation ID for log grepping. |
+| `containsKey(key)` | `boolean` | Whether a field error exists for `key`. |
+| `getErrorMessage(key)` | `string \| undefined` | Field error message. |
+| `getErrorMessageIfExists(key)` | `string` | Field error or the general message. |
+| `getFieldErrors()` | `Record<string, string>` | All field errors flattened. |
+| `ApiException.fromResponse(body, fallbackStatus?)` | `ApiException` | Build from a backend error envelope. |
+| `ApiException.convertAny(error)` | `ApiException` | Defensive fallback for unknown error values. |
 
-- `url` - Request URL
-- `data` - Request body
-- `options` - Request configuration (optional)
-- `dataKey` - Key to extract from response (default: 'data')
+### Shared utilities
 
-**Returns:** `Promise<Either<ApiException, T>>`
-
-#### `put<T>(url, data?, options?, dataKey?)`
-
-Same as `post()`
-
-#### `patch<T>(url, data?, options?, dataKey?)`
-
-Same as `post()` (fetchClient only)
-
-#### `delete<T>(url, options?, dataKey?)`
-
-Same as `get()`
-
-### Either Methods
-
-#### `isLeft(): boolean`
-
-Returns `true` if result contains an error.
-
-```typescript
-if (result.isLeft()) {
-  const error = result.value;
-}
+```ts
+import { toSearchParams } from '@/lib/utils/http';
 ```
 
-#### `isRight(): boolean`
+`toSearchParams(query)` — typed object → `URLSearchParams`. Skips `undefined`/`null`/`''`. Repeats array values.
 
-Returns `true` if result contains successful data.
+### Types
 
-```typescript
-if (result.isRight()) {
-  const data = result.value;
-}
-```
+All exported from `@/types`. See `src/types/common/` for the source of truth — these definitions are the contract.
 
-#### `fold<U>(onLeft, onRight): U`
-
-Pattern match on the result.
-
-```typescript
-const message = result.fold(
-  (error) => `Error: ${error.message}`,
-  (data) => `Success: ${data.length} items`,
-);
-```
-
-### ApiException Properties & Methods
-
-```typescript
-class ApiException extends Error {
-  status: number;
-  message: string;
-  errors?: Array<Record<string, string>>;
-  stack?: string;
-
-  // Check if specific field has validation error
-  containsKey(key: string): boolean;
-
-  // Get error message for specific field
-  getErrorMessage(key: string): string | undefined;
-
-  // Get error message or fallback to general message
-  getErrorMessageIfExists(key: string): string;
-
-  // Get all field errors as flat object
-  getFieldErrors(): Record<string, string>;
-}
-```
-
-**Example:**
-
-```typescript
-const result = await fetchClient.post('/users', { email: 'invalid' });
-
-if (result.isLeft()) {
-  const error = result.value;
-
-  // Properties
-  console.log(error.status); // 400
-  console.log(error.message); // "Validation failed"
-  console.log(error.errors); // [{ email: "Invalid format" }]
-
-  // Methods
-  error.containsKey('email'); // true
-  error.getErrorMessage('email'); // "Invalid format"
-  error.getErrorMessageIfExists('email'); // "Invalid format"
-  error.getFieldErrors(); // { email: "Invalid format" }
-}
-```
+- **Response envelopes:** `ApiResponse<T>`, `ApiErrorResponse`
+- **Pagination:** `ApiPaginationMeta`, `PaginatedApiResponse<T>`, `ApiCursorMeta`, `CursorPaginatedApiResponse<T>`
+- **Query inputs:** `BaseQueryParams`, `BaseCursorQueryParams` — extend these for endpoint-specific queries.
+- **Auth payloads:** `AuthUser`, `AuthTokens`, `AuthResponse`, `RefreshTokensResponse` — mirror the NestJS-starter DTOs.
+- **Transport:** `TokenStore`, `QueryParams`, `FetchClientOptions`, `AxiosClientOptions`, `ExtendedRequestInit`.
 
 ---
 
-## TypeScript Support
+## Best practices
 
-### Type-safe Responses
+Ranked by impact — the first three matter the most.
 
-```typescript
-interface User {
-  id: string;
-  name: string;
-  email: string;
-}
+### Do
 
-const result = await fetchClient.get<User>('/users/123');
+1. **Always type the response.** `fetchClient.get<User>(...)`, never `<any>`. The compiler can't help you without it.
+2. **Always handle both result branches.** `if (result.isLeft())` or `result.fold(...)` — never reach `.value` blindly.
+3. **Type the query.** Define `interface FooQuery extends BaseQueryParams { ... }` per endpoint; pass it via `{ params: query }`.
+4. **Log the request ID on failures.** `logger.error({ requestId: err.requestId }, ...)` — instant cross-stack tracing.
+5. **Centralise endpoints.** Keep route strings in `AppApis` rather than scattering literals across feature code.
+6. **One client per feature.** Don't mix `fetchClient` and `axiosClient` in the same module.
 
-if (result.isRight()) {
-  const user: User = result.value;
-  console.log(user.name);
-}
-```
+### Don't
 
-### Type-safe Paginated Responses
-
-```typescript
-import { PaginatedApiResponse, ApiPaginationMeta } from '@/types';
-
-interface User {
-  id: string;
-  name: string;
-  email: string;
-}
-
-const result = await fetchClient.get<PaginatedApiResponse<User>>('/users');
-
-if (result.isRight()) {
-  const { items, meta } = result.value;
-
-  // items is User[]
-  items.forEach((user) => console.log(user.name));
-
-  // meta is ApiPaginationMeta
-  console.log(meta.totalItems, meta.totalPages);
-}
-```
-
-### Available API Types
-
-```typescript
-// Standard API response wrapper
-interface ApiResponse<T> {
-  statusCode: number;
-  path: string;
-  message: string;
-  data: T;
-  timestamp: string;
-}
-
-// Pagination metadata
-interface ApiPaginationMeta {
-  totalItems: number;
-  totalPages: number;
-  currentPage: number;
-  pageSize: number;
-}
-
-// Paginated response
-interface PaginatedApiResponse<T> {
-  items: T[];
-  meta: ApiPaginationMeta;
-}
-```
-
-### Type-safe Requests
-
-```typescript
-interface CreateUserDto {
-  name: string;
-  email: string;
-  password: string;
-}
-
-const userData: CreateUserDto = {
-  name: 'John Doe',
-  email: 'john@example.com',
-  password: 'secret',
-};
-
-const result = await fetchClient.post<User>('/users', userData);
-```
-
----
-
-## Best Practices
-
-### ✅ DO
-
-```typescript
-// Use fetchClient for new code
-import { fetchClient } from '@/lib/utils/http';
-
-// Handle both success and error cases
-const result = await fetchClient.get('/data');
-if (result.isRight()) {
-  /* success */
-} else {
-  /* handle error */
-}
-
-// Use TypeScript types
-const result = await fetchClient.get<User[]>('/users');
-
-// Use descriptive variable names
-const getUserResult = await fetchClient.get(`/users/${id}`);
-```
-
-### ❌ DON'T
-
-```typescript
-// Don't ignore errors
-const result = await fetchClient.get('/data');
-const data = result.value; // ❌ Could be an error!
-
-// Don't use any type
-const result = await fetchClient.get<any>('/users'); // ❌
-
-// Don't mix clients unnecessarily
-import { axiosClient, fetchClient } from '@/lib/utils/http'; // ❌
-```
-
----
-
-## Environment Variables
-
-```env
-NEXT_PUBLIC_API_URL=https://api.example.com
-SAVE_AUTH_TOKENS=true
-```
-
-- `NEXT_PUBLIC_API_URL` - Base API URL (required)
-- `SAVE_AUTH_TOKENS` - Enable token storage (default: true)
-
----
-
-## Migration Guide
-
-### From fetch to fetchClient
-
-**Before:**
-
-```typescript
-const response = await fetch('/api/users');
-const data = await response.json();
-```
-
-**After:**
-
-```typescript
-const result = await fetchClient.get('/users');
-if (result.isRight()) {
-  const data = result.value;
-}
-```
-
-### From axios to fetchClient
-
-**Before:**
-
-```typescript
-try {
-  const response = await axios.get('/api/users');
-  const data = response.data;
-} catch (error) {
-  console.error(error);
-}
-```
-
-**After:**
-
-```typescript
-const result = await fetchClient.get('/users');
-result.fold(
-  (error) => console.error(error),
-  (data) => console.log(data),
-);
-```
+- ❌ Read tokens from `process.env`, `localStorage`, or anywhere outside `secureStorageTokenStore`.
+- ❌ Set `credentials: 'include'` manually — it's already the default.
+- ❌ Build `URLSearchParams` inline or accept positional `(page, size)` args — pass a typed query object via `{ params }`.
+- ❌ Bake `/api/v1` into `NEXT_PUBLIC_API_URL`.
+- ❌ Import `next/headers` from feature code — the clients already handle SSR cookie forwarding.
+- ❌ Use `<any>` as a response type. If the backend's shape is genuinely unknown, model it as `unknown` and narrow.
 
 ---
 
 ## Troubleshooting
 
-### Issue: "Max refresh attempts reached"
+### "Max refresh attempts reached"
 
-**Cause:** Token refresh endpoint is failing repeatedly.
+Backoff tripped (3 attempts within `COOLDOWN_MS = 1000`). Check that `POST /auth/refresh` actually rotates the refresh cookie / returns the new tokens. Common culprit: backend session was revoked while the frontend kept retrying.
 
-**Solution:** Check refresh token endpoint and credentials.
+### Always redirected to `/login` in dev
 
-### Issue: Redirected to login unexpectedly
+Cookie-mode requires the backend to set `access` / `refresh` cookies on a domain the frontend can read. In local dev this means same-host (e.g. both on `localhost`) or matching cookie domain. Check the backend's `COOKIE_DOMAIN` / `COOKIE_SAMESITE` env.
 
-**Cause:** Token refresh failed and `onUnauthorized` was called.
+### CORS errors with cookies
 
-**Solution:** Verify refresh token is valid and endpoint is accessible.
+Backend must allow the frontend's origin **and** `credentials: true`. The NestJS starter does this via a per-request origin validator (`src/bootstrap/utils/cors-validator.util.ts`) — add your frontend origin to its allow-list.
 
-### Issue: CORS errors
+### Types don't match the response
 
-**Cause:** API server not configured for CORS.
+Most often: backend wraps the payload in `{ data: ... }`, frontend already unwraps `data` by default. If you see `result.value.data.foo`, you've double-unwrapped — drop the `.data` or pass `null` as `dataKey` if you really want the envelope.
 
-**Solution:** Ensure API allows credentials and proper origins.
+### `X-Request-Id` missing on response
 
-### Issue: Types not matching
-
-**Cause:** Response structure doesn't match TypeScript interface.
-
-**Solution:** Verify API response structure or adjust `dataKey` parameter.
+Two causes:
+1. CORS — backend exposes `X-Request-Id` only on allow-listed origins.
+2. The backend rejected your supplied ID (didn't match `REQUEST_ID_PATTERN`) and the response had a different one. The error body's `requestId` is the authoritative value; the clients fall back to it automatically.
 
 ---
 
-## Examples
+## Related docs
 
-See the `/examples` directory for more usage examples:
-
-- Authentication flow
-- File uploads
-- Pagination
-- Real-time updates
-- Error recovery
-
----
-
-## Support
-
-For issues or questions:
-
-1. Check this documentation
-2. Review type definitions in `@/types/common/http.types.ts`
-3. Contact the development team
-
----
-
-**Last Updated:** November 2025
+- Backend response envelope, exception filter, request-id middleware → `nestjs-starter/src/core/{interceptors,filters,modules/request-context}`
+- Backend pagination DTOs → `nestjs-starter/src/core/dto/{base-query,base-cursor-query,pagination-response,cursor-response}.dto.ts`
+- Auth endpoint paths → `nestjs-starter/src/core/constants/app-paths.constants.ts`

--- a/src/lib/utils/http/axios-client/axios-client.test.ts
+++ b/src/lib/utils/http/axios-client/axios-client.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TokenStore } from '@/types';
+
+import { AxiosClient } from './axios-client';
+
+function makeTokenStore(): TokenStore {
+  return {
+    getAccessToken: () => Promise.resolve(null),
+    saveAccessToken: () => Promise.resolve(),
+    getRefreshToken: () => Promise.resolve(null),
+    saveRefreshToken: () => Promise.resolve(),
+    clear: () => Promise.resolve(),
+  };
+}
+
+/**
+ * Pull the underlying axios instance off `AxiosClient` (which keeps it
+ * `private`) so we can introspect its config without making real HTTP calls.
+ * The point of these tests is to regression-guard the `paramsSerializer`
+ * override; pulling it off the instance is the most direct way.
+ */
+function getAxiosDefaults(client: AxiosClient) {
+  return (client as unknown as { axios: { defaults: { paramsSerializer: unknown } } }).axios
+    .defaults;
+}
+
+describe('AxiosClient paramsSerializer (shared serialiser regression guard)', () => {
+  const client = new AxiosClient({
+    baseURL: 'https://api.example.com/api/v1',
+    tokenStore: makeTokenStore(),
+  });
+
+  function serialise(params: Record<string, unknown>): string {
+    const defaults = getAxiosDefaults(client);
+    const fn = defaults.paramsSerializer as (params: Record<string, unknown>) => string;
+    return fn(params);
+  }
+
+  it('produces the same output shape as the fetch client', () => {
+    expect(serialise({ page: 2, size: 20 })).toBe('page=2&size=20');
+  });
+
+  it('skips undefined/null/empty so backend defaults win', () => {
+    expect(serialise({ page: 1, size: undefined, search: '', sort: null })).toBe('page=1');
+  });
+
+  it('repeats keys for array values', () => {
+    expect(serialise({ tag: ['a', 'b', 'c'] })).toBe('tag=a&tag=b&tag=c');
+  });
+
+  it('coerces booleans and numbers', () => {
+    expect(serialise({ active: true, count: 0 })).toBe('active=true&count=0');
+  });
+
+  it('returns an empty string when every param is skipped', () => {
+    expect(serialise({ page: undefined, search: '' })).toBe('');
+  });
+});

--- a/src/lib/utils/http/axios-client/axios-client.ts
+++ b/src/lib/utils/http/axios-client/axios-client.ts
@@ -5,12 +5,13 @@ import axios, {
   type AxiosResponse,
 } from 'axios';
 
-import { API_RESPONSE_DATA_KEY } from '@/lib/config';
-import { env } from '@/lib/env';
+import { API_RESPONSE_DATA_KEY, getApiBaseUrl } from '@/lib/config';
 import { ApiException } from '@/lib/errors';
+import type { QueryParams } from '@/types';
 import { type AxiosClientOptions, type DataKey, left, type ResultAsync, right } from '@/types';
 
 import { extractDataByKey, TokenRefreshManager } from '../client-utils';
+import { extractRequestIdFromHeaderRecord, parseApiError, toSearchParams } from '../shared';
 import { setupRequestInterceptor, setupResponseInterceptor } from './interceptors';
 import { refreshAuthToken } from './token-refresh';
 
@@ -23,12 +24,16 @@ export class AxiosClient {
     this.tokenStore = options.tokenStore;
 
     this.axios = axios.create({
-      baseURL: options?.baseURL || env.NEXT_PUBLIC_API_URL,
+      baseURL: options?.baseURL || getApiBaseUrl(),
       withCredentials: true,
       timeout: 10000,
       headers: {
         'Content-Type': 'application/json',
+        ...options.defaultHeaders,
       },
+      // Use our shared serialiser so both clients produce identical query
+      // strings — skips undefined/null/empty, repeats array values.
+      paramsSerializer: (params) => toSearchParams(params as QueryParams).toString(),
     });
 
     setupRequestInterceptor(this.axios, this.tokenStore);
@@ -50,20 +55,15 @@ export class AxiosClient {
 
   private toApiException(err: unknown): ApiException {
     if (err instanceof AxiosError) {
-      const body = err.response?.data;
-      const exception = ApiException.fromResponse(
-        {
-          status: body?.status ?? err.response?.status,
-          message: body?.message || err.message,
-          code: body?.code,
-          errors: body?.errors,
-          data: body?.data,
-          path: body?.path,
-        },
-        err.response?.status ?? 0,
+      const responseRequestId = extractRequestIdFromHeaderRecord(
+        err.response?.headers as Record<string, unknown> | undefined,
       );
-      if (err.stack) exception.stack = err.stack;
-      return exception;
+      return parseApiError(
+        err.response?.data,
+        err.response?.status ?? 0,
+        responseRequestId,
+        err.stack,
+      );
     }
     return ApiException.convertAny(err);
   }

--- a/src/lib/utils/http/axios-client/interceptors.ts
+++ b/src/lib/utils/http/axios-client/interceptors.ts
@@ -8,30 +8,61 @@ import type {
 import { SAVE_AUTH_TOKENS } from '@/lib/config';
 import type { TokenStore } from '@/types';
 
+import {
+  generateRequestId,
+  getCookieHeaderForRequest,
+  isValidRequestId,
+  REQUEST_ID_HEADER,
+} from '../shared';
+
+function readHeaderInsensitive(
+  headers: InternalAxiosRequestConfig['headers'],
+  name: string,
+): string | undefined {
+  if (!headers) return undefined;
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lower && typeof value === 'string') return value;
+  }
+  return undefined;
+}
+
 export function setupRequestInterceptor(
   axiosInstance: AxiosInstance,
   tokenStore: TokenStore,
 ): void {
   axiosInstance.interceptors.request.use(
     async (config: InternalAxiosRequestConfig) => {
+      // Request-ID: stamp every outgoing request unless the caller supplied
+      // a valid one. Matches the backend's REQUEST_ID_PATTERN so the value
+      // is echoed back rather than rewritten server-side.
+      const providedId = readHeaderInsensitive(config.headers, REQUEST_ID_HEADER);
+      if (!(providedId && isValidRequestId(providedId))) {
+        config.headers.set(REQUEST_ID_HEADER, generateRequestId());
+      }
+
+      // Cookie forwarding for server runtimes (RSC / Server Actions / Route
+      // Handlers). `withCredentials: true` is browser-only — Node has no
+      // cookie jar and silently drops it.
+      if (!readHeaderInsensitive(config.headers, 'cookie')) {
+        const cookieHeader = await getCookieHeaderForRequest();
+        if (cookieHeader) config.headers.set('Cookie', cookieHeader);
+      }
+
       if (config._skipAuthInterceptor) {
         return config;
       }
 
       if (SAVE_AUTH_TOKENS) {
         const token = await tokenStore.getAccessToken();
-
         if (token) {
-          config.headers = config.headers ?? {};
-          config.headers.Authorization = `Bearer ${token}`;
+          config.headers.set('Authorization', `Bearer ${token}`);
         }
       }
 
       return config;
     },
-    (error) => {
-      return Promise.reject(error);
-    },
+    (error) => Promise.reject(error),
   );
 }
 
@@ -44,10 +75,11 @@ export function setupResponseInterceptor(
   axiosInstance.interceptors.response.use(
     (res) => res,
     async (error: AxiosError) => {
-      const originalRequest = error.config as AxiosRequestConfig;
+      const originalRequest = error.config as AxiosRequestConfig | undefined;
 
       if (
         error.response?.status === 401 &&
+        originalRequest &&
         !originalRequest._retry &&
         !originalRequest._skipAuthInterceptor
       ) {
@@ -62,7 +94,7 @@ export function setupResponseInterceptor(
         }
 
         originalRequest.headers = originalRequest.headers ?? {};
-        originalRequest.headers.Authorization = `Bearer ${token}`;
+        (originalRequest.headers as Record<string, string>).Authorization = `Bearer ${token}`;
 
         return axiosInstance(originalRequest);
       }

--- a/src/lib/utils/http/axios-client/token-refresh.test.ts
+++ b/src/lib/utils/http/axios-client/token-refresh.test.ts
@@ -1,0 +1,114 @@
+import type { AxiosInstance } from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TokenStore } from '@/types';
+
+import { refreshAuthToken } from './token-refresh';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const SAVE_AUTH_TOKENS = { value: false };
+vi.mock('@/lib/config', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/config')>('@/lib/config');
+  return {
+    ...actual,
+    get SAVE_AUTH_TOKENS() {
+      return SAVE_AUTH_TOKENS.value;
+    },
+  };
+});
+
+function makeTokenStore(overrides: Partial<TokenStore> = {}): TokenStore {
+  return {
+    getAccessToken: vi.fn().mockResolvedValue(null),
+    saveAccessToken: vi.fn().mockResolvedValue(undefined),
+    getRefreshToken: vi.fn().mockResolvedValue(null),
+    saveRefreshToken: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeAxiosStub(post: ReturnType<typeof vi.fn>): AxiosInstance {
+  return { post } as unknown as AxiosInstance;
+}
+
+describe('axios refreshAuthToken', () => {
+  beforeEach(() => {
+    SAVE_AUTH_TOKENS.value = false;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('posts to /auth/refresh (not /auth/refresh-token)', async () => {
+    const post = vi.fn().mockResolvedValue({
+      data: {
+        data: {
+          accessToken: 'new-access',
+          refreshToken: 'new-refresh',
+          expiresIn: 900,
+          sessionId: 'sess-1',
+        },
+      },
+    });
+
+    const result = await refreshAuthToken(makeTokenStore(), makeAxiosStub(post));
+
+    expect(result).toBe('new-access');
+    expect(post).toHaveBeenCalledWith(
+      '/auth/refresh',
+      {},
+      expect.objectContaining({ _skipAuthInterceptor: true }),
+    );
+  });
+
+  it('cookie mode: omits Authorization header even when refresh token is stored', async () => {
+    const post = vi.fn().mockResolvedValue({
+      data: { data: { accessToken: 'a', refreshToken: 'r', expiresIn: 1, sessionId: 's' } },
+    });
+
+    await refreshAuthToken(
+      makeTokenStore({ getRefreshToken: vi.fn().mockResolvedValue('stored-refresh') }),
+      makeAxiosStub(post),
+    );
+
+    const config = post.mock.calls[0][2];
+    expect(config.headers.Authorization).toBeUndefined();
+  });
+
+  it('bearer mode: sends Authorization: Bearer <refreshToken> and persists tokens', async () => {
+    SAVE_AUTH_TOKENS.value = true;
+    const post = vi.fn().mockResolvedValue({
+      data: {
+        data: {
+          accessToken: 'new-access',
+          refreshToken: 'new-refresh',
+          expiresIn: 900,
+          sessionId: 's',
+        },
+      },
+    });
+
+    const store = makeTokenStore({
+      getRefreshToken: vi.fn().mockResolvedValue('stored-refresh'),
+    });
+
+    const result = await refreshAuthToken(store, makeAxiosStub(post));
+
+    expect(result).toBe('new-access');
+    const config = post.mock.calls[0][2];
+    expect(config.headers.Authorization).toBe('Bearer stored-refresh');
+    expect(store.saveAccessToken).toHaveBeenCalledWith('new-access');
+    expect(store.saveRefreshToken).toHaveBeenCalledWith('new-refresh');
+  });
+
+  it('returns null on axios error', async () => {
+    const post = vi.fn().mockRejectedValue(new Error('boom'));
+    const result = await refreshAuthToken(makeTokenStore(), makeAxiosStub(post));
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/utils/http/axios-client/token-refresh.ts
+++ b/src/lib/utils/http/axios-client/token-refresh.ts
@@ -3,36 +3,50 @@ import type { AxiosInstance } from 'axios';
 import { SAVE_AUTH_TOKENS } from '@/lib/config';
 import { AppApis } from '@/lib/config/app-apis';
 import { logger } from '@/lib/logger';
-import type { AuthTokens, TokenStore } from '@/types';
+import type { RefreshTokensResponse, TokenStore } from '@/types';
 
+/**
+ * Rotate the access/refresh token pair via `POST /auth/refresh`.
+ *
+ * Mirror of the fetch-client variant. Cookie-mode (default): refresh token
+ * rides the `refresh` HttpOnly cookie via `withCredentials`. Bearer-mode
+ * (`SAVE_AUTH_TOKENS=true`): the stored refresh token is sent as Bearer.
+ *
+ * Backend response shape (`RefreshTokensResponseDto`):
+ *   { accessToken, refreshToken, expiresIn, sessionId }
+ * wrapped in the standard `{ data: ... }` envelope.
+ */
 export async function refreshAuthToken(
   tokenStore: TokenStore,
   axiosInstance: AxiosInstance,
 ): Promise<string | null> {
   try {
-    const currentRefreshToken = await tokenStore.getRefreshToken();
+    const headers: Record<string, string> = {};
 
-    const res = await axiosInstance.post<{ data: AuthTokens }>(
-      AppApis.auth.refreshToken,
+    if (SAVE_AUTH_TOKENS) {
+      const currentRefreshToken = await tokenStore.getRefreshToken();
+      if (currentRefreshToken) {
+        headers.Authorization = `Bearer ${currentRefreshToken}`;
+      }
+    }
+
+    const res = await axiosInstance.post<{ data: RefreshTokensResponse }>(
+      AppApis.auth.refresh,
       {},
       {
         _skipAuthInterceptor: true,
-        headers: currentRefreshToken
-          ? {
-              Authorization: `Bearer ${currentRefreshToken}`,
-            }
-          : undefined,
+        headers,
       },
     );
 
-    const { access, refresh } = res.data.data;
+    const { accessToken, refreshToken } = res.data.data;
 
     if (SAVE_AUTH_TOKENS) {
-      await tokenStore.saveAccessToken(access);
-      await tokenStore.saveRefreshToken(refresh);
+      await tokenStore.saveAccessToken(accessToken);
+      await tokenStore.saveRefreshToken(refreshToken);
     }
 
-    return access;
+    return accessToken;
   } catch (error) {
     logger.error({ err: error }, 'Token refresh failed');
     return null;

--- a/src/lib/utils/http/client-utils.test.ts
+++ b/src/lib/utils/http/client-utils.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  extractDataByKey,
+  handleUnauthorizedRedirect,
+  TOKEN_REFRESH_CONFIG,
+  TokenRefreshManager,
+} from './client-utils';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+describe('extractDataByKey', () => {
+  it('returns the raw value when dataKey is null/undefined', () => {
+    expect(extractDataByKey({ data: 1 }, null)).toEqual({ data: 1 });
+    expect(extractDataByKey({ data: 1 }, undefined)).toEqual({ data: 1 });
+  });
+
+  it('extracts the named key when present', () => {
+    expect(extractDataByKey<number>({ data: 42 }, 'data')).toBe(42);
+    expect(extractDataByKey<string>({ items: 'x', meta: 'y' }, 'items')).toBe('x');
+  });
+
+  it('returns the raw value when the key is missing', () => {
+    const raw = { foo: 1 };
+    expect(extractDataByKey(raw, 'data')).toBe(raw);
+  });
+
+  it('returns the raw value when input is not an object', () => {
+    expect(extractDataByKey<number>(42, 'data')).toBe(42);
+    expect(extractDataByKey(null, 'data')).toBe(null);
+  });
+});
+
+describe('TokenRefreshManager', () => {
+  let manager: TokenRefreshManager;
+
+  beforeEach(() => {
+    manager = new TokenRefreshManager();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the token from the refresh function', async () => {
+    const refreshFn = vi.fn().mockResolvedValue('new-token');
+    const result = await manager.handleRefresh(refreshFn);
+    expect(result).toBe('new-token');
+    expect(refreshFn).toHaveBeenCalledOnce();
+  });
+
+  it('queues concurrent callers and drains them with the same token', async () => {
+    let resolveRefresh: (t: string | null) => void = () => {};
+    const refreshFn = vi.fn(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    // First caller triggers the refresh; subsequent callers should queue.
+    const p1 = manager.handleRefresh(refreshFn);
+    const p2 = manager.handleRefresh(refreshFn);
+    const p3 = manager.handleRefresh(refreshFn);
+
+    resolveRefresh('shared-token');
+
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+    expect(refreshFn).toHaveBeenCalledOnce(); // only the first caller invokes
+    expect(r1).toBe('shared-token');
+    expect(r2).toBe('shared-token');
+    expect(r3).toBe('shared-token');
+  });
+
+  it('returns null when refreshFn returns null and drains queue with null', async () => {
+    let resolveRefresh: (t: string | null) => void = () => {};
+    const refreshFn = vi.fn(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    const p1 = manager.handleRefresh(refreshFn);
+    const p2 = manager.handleRefresh(refreshFn);
+
+    resolveRefresh(null);
+
+    expect(await p1).toBeNull();
+    expect(await p2).toBeNull();
+  });
+
+  it('drains queue with null when refreshFn throws', async () => {
+    let rejectRefresh: (reason: unknown) => void = () => {};
+    const refreshFn = vi.fn(
+      () =>
+        new Promise<string | null>((_, reject) => {
+          rejectRefresh = reject;
+        }),
+    );
+
+    const p1 = manager.handleRefresh(refreshFn);
+    const p2 = manager.handleRefresh(refreshFn);
+
+    rejectRefresh(new Error('boom'));
+
+    expect(await p1).toBeNull();
+    expect(await p2).toBeNull();
+  });
+
+  it('returns null and resets after MAX_ATTEMPTS within COOLDOWN_MS', async () => {
+    const refreshFn = vi.fn().mockResolvedValue('t');
+
+    // First call passes (attempts counter starts at 0, no cooldown comparison applies).
+    // Calls 2, 3 within cooldown bump attempts to 1, 2 — still under MAX_ATTEMPTS=3.
+    // Call 4 within cooldown bumps attempts to 3 — trips the guard, returns null.
+    await manager.handleRefresh(refreshFn);
+    await manager.handleRefresh(refreshFn);
+    await manager.handleRefresh(refreshFn);
+    const tripped = await manager.handleRefresh(refreshFn);
+
+    expect(tripped).toBeNull();
+    expect(refreshFn).toHaveBeenCalledTimes(3); // 4th call short-circuits before invoking
+  });
+
+  it('resets the attempt counter after cooldown elapses', async () => {
+    const refreshFn = vi.fn().mockResolvedValue('t');
+
+    // Pump the counter up close to the limit (attempts becomes 2 after these three calls).
+    await manager.handleRefresh(refreshFn);
+    await manager.handleRefresh(refreshFn);
+    await manager.handleRefresh(refreshFn);
+
+    // Advance past the cooldown so the next call hits the reset branch.
+    vi.setSystemTime(Date.now() + TOKEN_REFRESH_CONFIG.COOLDOWN_MS + 100);
+
+    // This would have tripped MAX_ATTEMPTS without the reset; now it goes through.
+    const result = await manager.handleRefresh(refreshFn);
+    expect(result).toBe('t');
+    expect(refreshFn).toHaveBeenCalledTimes(4);
+  });
+
+  it('allows a follow-up refresh after one completes (isRefreshing flag is reset)', async () => {
+    const refreshFn = vi
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValueOnce('first')
+      .mockResolvedValueOnce('second');
+
+    expect(await manager.handleRefresh(refreshFn)).toBe('first');
+    expect(await manager.handleRefresh(refreshFn)).toBe('second');
+  });
+});
+
+describe('handleUnauthorizedRedirect', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // jsdom exposes window.location with a configurable href setter.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { pathname: '/secret', search: '?foo=bar', href: 'http://localhost/' },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('redirects to the login path with the current URL encoded as redirectTo', () => {
+    handleUnauthorizedRedirect();
+    expect(window.location.href).toMatch(/redirectTo=%2Fsecret%3Ffoo%3Dbar$/);
+  });
+});

--- a/src/lib/utils/http/fetch-client/fetch-client.test.ts
+++ b/src/lib/utils/http/fetch-client/fetch-client.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiException } from '@/lib/errors';
+import type { TokenStore } from '@/types';
+
+import { FetchClient } from './fetch-client';
+import * as tokenRefreshModule from './token-refresh';
+
+function makeTokenStore(overrides: Partial<TokenStore> = {}): TokenStore {
+  return {
+    getAccessToken: vi.fn().mockResolvedValue(null),
+    saveAccessToken: vi.fn().mockResolvedValue(undefined),
+    getRefreshToken: vi.fn().mockResolvedValue(null),
+    saveRefreshToken: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function jsonResponse(payload: unknown, status = 200, extraHeaders?: HeadersInit): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
+  });
+}
+
+const BASE = 'https://api.example.com/api/v1';
+
+describe('FetchClient params option', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let client: FetchClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+    client = new FetchClient({ baseURL: BASE, tokenStore: makeTokenStore() });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('serialises params onto the URL', async () => {
+    await client.get('/users', { params: { page: 2, size: 20 } });
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/users?page=2&size=20`);
+  });
+
+  it('skips undefined/null/empty values so backend defaults win', async () => {
+    await client.get('/users', {
+      params: { page: 1, size: undefined, search: '', sort: null as unknown as string },
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/users?page=1`);
+  });
+
+  it('repeats keys for array values', async () => {
+    await client.get('/users', { params: { tag: ['a', 'b'] } });
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/users?tag=a&tag=b`);
+  });
+
+  it('uses & when the URL already has a query string', async () => {
+    await client.get('/users?role=admin', { params: { page: 2 } });
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/users?role=admin&page=2`);
+  });
+
+  it('omits ? entirely when all params serialise to empty', async () => {
+    await client.get('/users', { params: { page: undefined, search: '' } });
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/users`);
+  });
+
+  it('does not forward params as a fetch RequestInit field', async () => {
+    await client.get('/users', { params: { page: 1 } });
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as Record<string, unknown>).params).toBeUndefined();
+  });
+});
+
+describe('FetchClient response unwrapping (dataKey)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let client: FetchClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    client = new FetchClient({ baseURL: BASE, tokenStore: makeTokenStore() });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('default dataKey="data" unwraps the envelope data field', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ status: 200, data: { id: '42' }, timestamp: 'x' }));
+    const result = await client.get<{ id: string }>('/users/42');
+    expect(result.isRight()).toBe(true);
+    if (result.isRight()) expect(result.value).toEqual({ id: '42' });
+  });
+
+  it('dataKey=null returns the whole envelope', async () => {
+    const envelope = { status: 200, data: { id: '42' }, timestamp: 'x' };
+    fetchMock.mockResolvedValue(jsonResponse(envelope));
+    const result = await client.get('/users/42', undefined, null);
+    expect(result.isRight()).toBe(true);
+    if (result.isRight()) expect(result.value).toEqual(envelope);
+  });
+
+  it('custom dataKey unwraps the named field', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ items: [1, 2, 3] }));
+    const result = await client.get<number[]>('/users', undefined, 'items');
+    expect(result.isRight()).toBe(true);
+    if (result.isRight()) expect(result.value).toEqual([1, 2, 3]);
+  });
+});
+
+describe('FetchClient error handling', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let client: FetchClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    client = new FetchClient({ baseURL: BASE, tokenStore: makeTokenStore() });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns a left ApiException carrying status / message / code / requestId', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        {
+          status: 422,
+          path: '/api/v1/users',
+          message: 'Validation failed',
+          code: 'VALIDATION_ERROR',
+          errors: [{ email: 'Invalid format' }],
+          requestId: 'req-abc',
+        },
+        422,
+      ),
+    );
+
+    const result = await client.post('/users', { email: 'bad' });
+    expect(result.isLeft()).toBe(true);
+    if (result.isLeft()) {
+      const err = result.value;
+      expect(err).toBeInstanceOf(ApiException);
+      expect(err.status).toBe(422);
+      expect(err.message).toBe('Validation failed');
+      expect(err.code).toBe('VALIDATION_ERROR');
+      expect(err.requestId).toBe('req-abc');
+      expect(err.getErrorMessage('email')).toBe('Invalid format');
+    }
+  });
+
+  it('falls back to the X-Request-Id header when the body has no requestId', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ status: 500, message: 'Boom' }, 500, { 'X-Request-Id': 'req-from-header' }),
+    );
+
+    const result = await client.get('/users');
+    expect(result.isLeft()).toBe(true);
+    if (result.isLeft()) expect(result.value.requestId).toBe('req-from-header');
+  });
+
+  it('converts a network failure into an ApiException with status 0', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await client.get('/users');
+    expect(result.isLeft()).toBe(true);
+    if (result.isLeft()) {
+      expect(result.value.status).toBe(0);
+      expect(result.value.message).toBe('ECONNREFUSED');
+    }
+  });
+});
+
+describe('FetchClient 401 → refresh → retry lifecycle', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let refreshSpy: ReturnType<typeof vi.spyOn>;
+  let onUnauthorized: () => void;
+  let tokenStore: TokenStore;
+  let client: FetchClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    refreshSpy = vi.spyOn(tokenRefreshModule, 'refreshAuthToken');
+    onUnauthorized = vi.fn<() => void>();
+    tokenStore = makeTokenStore();
+    client = new FetchClient({ baseURL: BASE, tokenStore, onUnauthorized });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('retries the original request with the fresh token on 401 → refresh success', async () => {
+    refreshSpy.mockResolvedValue('new-access-token');
+
+    fetchMock
+      .mockResolvedValueOnce(new Response('', { status: 401 }))
+      .mockResolvedValueOnce(jsonResponse({ data: { ok: true } }));
+
+    const result = await client.get<{ ok: boolean }>('/me');
+
+    expect(refreshSpy).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Second call must carry the new token in the Authorization header.
+    const [, retryInit] = fetchMock.mock.calls[1];
+    const retryHeaders = (retryInit as RequestInit).headers as Record<string, string>;
+    expect(retryHeaders.Authorization).toBe('Bearer new-access-token');
+    expect(result.isRight()).toBe(true);
+    if (result.isRight()) expect(result.value).toEqual({ ok: true });
+  });
+
+  it('clears the token store, calls onUnauthorized, and returns left when refresh fails', async () => {
+    refreshSpy.mockResolvedValue(null);
+    fetchMock.mockResolvedValue(jsonResponse({ status: 401, message: 'Unauthorized' }, 401));
+
+    const result = await client.get('/me');
+
+    expect(refreshSpy).toHaveBeenCalledOnce();
+    expect(tokenStore.clear).toHaveBeenCalledOnce();
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no retry
+    expect(result.isLeft()).toBe(true);
+    if (result.isLeft()) expect(result.value.status).toBe(401);
+  });
+
+  it('does not attempt refresh when _skipAuthInterceptor is set', async () => {
+    fetchMock.mockResolvedValue(new Response('', { status: 401 }));
+
+    const result = await client.get('/public', { _skipAuthInterceptor: true });
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(result.isLeft()).toBe(true);
+  });
+});
+
+describe('FetchClient URL composition', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let client: FetchClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: null }));
+    vi.stubGlobal('fetch', fetchMock);
+    client = new FetchClient({ baseURL: BASE, tokenStore: makeTokenStore() });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('passes through absolute URLs unchanged (no baseURL prefix)', async () => {
+    await client.get('https://other.example.com/raw');
+    expect(fetchMock.mock.calls[0][0]).toBe('https://other.example.com/raw');
+  });
+
+  it('normalises double-slashes between base and path', async () => {
+    await client.get('/users');
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/users`);
+
+    await client.get('users');
+    expect(fetchMock.mock.calls[1][0]).toBe(`${BASE}/users`);
+  });
+});

--- a/src/lib/utils/http/fetch-client/fetch-client.ts
+++ b/src/lib/utils/http/fetch-client/fetch-client.ts
@@ -1,9 +1,16 @@
-import { API_RESPONSE_DATA_KEY } from '@/lib/config';
-import { env } from '@/lib/env';
+import { API_RESPONSE_DATA_KEY, getApiBaseUrl } from '@/lib/config';
 import { ApiException } from '@/lib/errors';
-import { type DataKey, type FetchClientOptions, left, type ResultAsync, right } from '@/types';
+import {
+  type DataKey,
+  type ExtendedRequestInit,
+  type FetchClientOptions,
+  left,
+  type ResultAsync,
+  right,
+} from '@/types';
 
 import { extractDataByKey, TokenRefreshManager } from '../client-utils';
+import { extractRequestIdFromHeaders, parseApiError, toSearchParams } from '../shared';
 import { applyRequestInterceptors, applyResponseInterceptors } from './interceptors';
 import { refreshAuthToken } from './token-refresh';
 
@@ -15,7 +22,7 @@ export class FetchClient {
   private refreshManager = new TokenRefreshManager();
 
   constructor(options: FetchClientOptions) {
-    this.baseURL = options?.baseURL || env.NEXT_PUBLIC_API_URL || '';
+    this.baseURL = options?.baseURL || getApiBaseUrl();
     this.tokenStore = options.tokenStore;
     this.onUnauthorized = options.onUnauthorized;
 
@@ -33,36 +40,16 @@ export class FetchClient {
     return this.refreshManager.handleRefresh(() => refreshAuthToken(this.tokenStore, this.baseURL));
   }
 
-  private toApiException(error: unknown, response?: Response): ApiException {
-    if (error instanceof ApiException) {
-      return error;
-    }
+  private toApiException(error: unknown, response?: Response, body?: unknown): ApiException {
+    if (error instanceof ApiException) return error;
 
     if (response) {
-      const body = (typeof error === 'object' && error !== null ? error : {}) as Record<
-        string,
-        unknown
-      >;
-      const exception = ApiException.fromResponse(
-        {
-          status: typeof body.status === 'number' ? body.status : response.status,
-          message:
-            typeof body.message === 'string'
-              ? body.message
-              : `Request failed with status ${response.status}`,
-          code: typeof body.code === 'string' ? body.code : undefined,
-          errors: Array.isArray(body.errors)
-            ? (body.errors as Record<string, string>[])
-            : undefined,
-          data:
-            typeof body.data === 'object' && body.data !== null
-              ? (body.data as Record<string, unknown>)
-              : undefined,
-          path: typeof body.path === 'string' ? body.path : undefined,
-        },
+      const exception = parseApiError(
+        body ?? error,
         response.status,
+        extractRequestIdFromHeaders(response.headers),
+        error instanceof Error ? error.stack : undefined,
       );
-      if (error instanceof Error && error.stack) exception.stack = error.stack;
       return exception;
     }
 
@@ -77,29 +64,32 @@ export class FetchClient {
     return ApiException.convertAny(error);
   }
 
-  private buildURL(url: string): string {
-    if (url.startsWith('http://') || url.startsWith('https://')) {
-      return url;
-    }
-    const normalizedURL = url.startsWith('/') ? url.slice(1) : url;
-    const normalizedBase = this.baseURL.endsWith('/') ? this.baseURL.slice(0, -1) : this.baseURL;
-    return `${normalizedBase}/${normalizedURL}`;
+  private buildURL(url: string, params?: ExtendedRequestInit['params']): string {
+    const absolute =
+      url.startsWith('http://') || url.startsWith('https://')
+        ? url
+        : `${this.baseURL.replace(/\/$/, '')}/${url.replace(/^\//, '')}`;
+
+    if (!params) return absolute;
+
+    const search = toSearchParams(params).toString();
+    if (!search) return absolute;
+
+    const separator = absolute.includes('?') ? '&' : '?';
+    return `${absolute}${separator}${search}`;
   }
 
   private async request<T>(
     url: string,
-    options: RequestInit & {
-      _retry?: boolean;
-      _skipAuthInterceptor?: boolean;
-      _authToken?: string;
-    } = {},
+    options: ExtendedRequestInit = {},
     dataKey?: DataKey,
   ): ResultAsync<T> {
-    const fullURL = this.buildURL(url);
+    const { params, ...fetchOptions } = options;
+    const fullURL = this.buildURL(url, params);
 
     try {
       const interceptedOptions = await applyRequestInterceptors(
-        options,
+        fetchOptions,
         this.tokenStore,
         this.defaultOptions,
       );
@@ -138,26 +128,8 @@ export class FetchClient {
         );
       }
 
-      if (interceptResult.shouldReject) {
-        const errorData = responseData as { message?: string; errors?: Record<string, string>[] };
-        return left(
-          new ApiException({
-            status: response.status,
-            message: errorData?.message || 'Unauthorized',
-            errors: errorData?.errors,
-          }),
-        );
-      }
-
-      if (!response.ok) {
-        const errorData = responseData as { message?: string; errors?: Record<string, string>[] };
-        return left(
-          new ApiException({
-            status: response.status,
-            message: errorData?.message || `Request failed with status ${response.status}`,
-            errors: errorData?.errors,
-          }),
-        );
+      if (interceptResult.shouldReject || !response.ok) {
+        return left(this.toApiException(undefined, response, responseData));
       }
 
       return right(extractDataByKey<T>(responseData, dataKey));
@@ -168,7 +140,7 @@ export class FetchClient {
 
   async get<T>(
     url: string,
-    options?: RequestInit,
+    options?: ExtendedRequestInit,
     dataKey: DataKey = API_RESPONSE_DATA_KEY,
   ): ResultAsync<T> {
     return this.request<T>(url, { ...options, method: 'GET' }, dataKey);
@@ -177,7 +149,7 @@ export class FetchClient {
   async post<T>(
     url: string,
     data?: unknown,
-    options?: RequestInit,
+    options?: ExtendedRequestInit,
     dataKey: DataKey = API_RESPONSE_DATA_KEY,
   ): ResultAsync<T> {
     return this.request<T>(
@@ -194,7 +166,7 @@ export class FetchClient {
   async put<T>(
     url: string,
     data?: unknown,
-    options?: RequestInit,
+    options?: ExtendedRequestInit,
     dataKey: DataKey = API_RESPONSE_DATA_KEY,
   ): ResultAsync<T> {
     return this.request<T>(
@@ -211,7 +183,7 @@ export class FetchClient {
   async patch<T>(
     url: string,
     data?: unknown,
-    options?: RequestInit,
+    options?: ExtendedRequestInit,
     dataKey: DataKey = API_RESPONSE_DATA_KEY,
   ): ResultAsync<T> {
     return this.request<T>(
@@ -227,7 +199,7 @@ export class FetchClient {
 
   async delete<T>(
     url: string,
-    options?: RequestInit,
+    options?: ExtendedRequestInit,
     dataKey: DataKey = API_RESPONSE_DATA_KEY,
   ): ResultAsync<T> {
     return this.request<T>(url, { ...options, method: 'DELETE' }, dataKey);

--- a/src/lib/utils/http/fetch-client/interceptors.test.ts
+++ b/src/lib/utils/http/fetch-client/interceptors.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TokenStore } from '@/types';
+
+import { REQUEST_ID_HEADER, REQUEST_ID_PATTERN } from '../shared';
+
+vi.mock('../shared', async () => {
+  const actual = await vi.importActual<typeof import('../shared')>('../shared');
+  return {
+    ...actual,
+    getCookieHeaderForRequest: vi.fn(),
+  };
+});
+
+const SAVE_AUTH_TOKENS = { value: false };
+vi.mock('@/lib/config', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/config')>('@/lib/config');
+  return {
+    ...actual,
+    get SAVE_AUTH_TOKENS() {
+      return SAVE_AUTH_TOKENS.value;
+    },
+  };
+});
+
+// Imports must come AFTER mocks.
+const { applyRequestInterceptors, applyResponseInterceptors } = await import('./interceptors');
+const { getCookieHeaderForRequest } = await import('../shared');
+const getCookieMock = vi.mocked(getCookieHeaderForRequest);
+
+function makeTokenStore(overrides: Partial<TokenStore> = {}): TokenStore {
+  return {
+    getAccessToken: vi.fn().mockResolvedValue(null),
+    saveAccessToken: vi.fn().mockResolvedValue(undefined),
+    getRefreshToken: vi.fn().mockResolvedValue(null),
+    saveRefreshToken: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('applyRequestInterceptors', () => {
+  beforeEach(() => {
+    SAVE_AUTH_TOKENS.value = false;
+    getCookieMock.mockReset();
+    getCookieMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('generates a fresh X-Request-Id when none provided', async () => {
+    const out = await applyRequestInterceptors({}, makeTokenStore(), {});
+    const headers = out.headers as Record<string, string>;
+    expect(headers[REQUEST_ID_HEADER]).toMatch(REQUEST_ID_PATTERN);
+  });
+
+  it('preserves a valid caller-supplied X-Request-Id', async () => {
+    const out = await applyRequestInterceptors(
+      { headers: { [REQUEST_ID_HEADER]: 'caller-supplied-id' } },
+      makeTokenStore(),
+      {},
+    );
+    const headers = out.headers as Record<string, string>;
+    expect(headers[REQUEST_ID_HEADER]).toBe('caller-supplied-id');
+  });
+
+  it('replaces an invalid caller-supplied X-Request-Id', async () => {
+    const out = await applyRequestInterceptors(
+      { headers: { [REQUEST_ID_HEADER]: 'has spaces and !@#' } },
+      makeTokenStore(),
+      {},
+    );
+    const headers = out.headers as Record<string, string>;
+    expect(headers[REQUEST_ID_HEADER]).not.toBe('has spaces and !@#');
+    expect(headers[REQUEST_ID_HEADER]).toMatch(REQUEST_ID_PATTERN);
+  });
+
+  it('injects a Cookie header from getCookieHeaderForRequest when one is returned', async () => {
+    getCookieMock.mockResolvedValue('session=abc');
+    const out = await applyRequestInterceptors({}, makeTokenStore(), {});
+    const headers = out.headers as Record<string, string>;
+    expect(headers.Cookie).toBe('session=abc');
+  });
+
+  it('omits Cookie when getCookieHeaderForRequest returns undefined (browser branch)', async () => {
+    getCookieMock.mockResolvedValue(undefined);
+    const out = await applyRequestInterceptors({}, makeTokenStore(), {});
+    const headers = out.headers as Record<string, string>;
+    expect(headers.Cookie).toBeUndefined();
+  });
+
+  it('does not overwrite a caller-supplied Cookie header', async () => {
+    getCookieMock.mockResolvedValue('injected=value');
+    const out = await applyRequestInterceptors(
+      { headers: { Cookie: 'caller=value' } },
+      makeTokenStore(),
+      {},
+    );
+    const headers = out.headers as Record<string, string>;
+    expect(headers.Cookie).toBe('caller=value');
+    expect(getCookieMock).not.toHaveBeenCalled();
+  });
+
+  it('does not attach Authorization in cookie-mode (SAVE_AUTH_TOKENS=false)', async () => {
+    const tokenStore = makeTokenStore({
+      getAccessToken: vi.fn().mockResolvedValue('stored-token'),
+    });
+    const out = await applyRequestInterceptors({}, tokenStore, {});
+    const headers = out.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    expect(tokenStore.getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('attaches Authorization: Bearer <token> in bearer-mode (SAVE_AUTH_TOKENS=true)', async () => {
+    SAVE_AUTH_TOKENS.value = true;
+    const tokenStore = makeTokenStore({
+      getAccessToken: vi.fn().mockResolvedValue('stored-token'),
+    });
+    const out = await applyRequestInterceptors({}, tokenStore, {});
+    const headers = out.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer stored-token');
+  });
+
+  it('_skipAuthInterceptor bypasses all token logic', async () => {
+    SAVE_AUTH_TOKENS.value = true;
+    const tokenStore = makeTokenStore({
+      getAccessToken: vi.fn().mockResolvedValue('stored-token'),
+    });
+    const out = await applyRequestInterceptors({ _skipAuthInterceptor: true }, tokenStore, {});
+    const headers = out.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    expect(tokenStore.getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('_authToken takes precedence over the stored access token', async () => {
+    SAVE_AUTH_TOKENS.value = true;
+    const tokenStore = makeTokenStore({
+      getAccessToken: vi.fn().mockResolvedValue('stale-token'),
+    });
+    const out = await applyRequestInterceptors(
+      { _authToken: 'fresh-token-from-retry' },
+      tokenStore,
+      {},
+    );
+    const headers = out.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer fresh-token-from-retry');
+  });
+
+  it('_authToken works even in cookie-mode (so retries after refresh still send the new token)', async () => {
+    SAVE_AUTH_TOKENS.value = false;
+    const out = await applyRequestInterceptors(
+      { _authToken: 'token-from-refresh' },
+      makeTokenStore(),
+      {},
+    );
+    const headers = out.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer token-from-refresh');
+  });
+});
+
+describe('applyResponseInterceptors', () => {
+  it('does nothing on non-401 responses', async () => {
+    const handleRefresh = vi.fn();
+    const result = await applyResponseInterceptors(
+      new Response('', { status: 200 }),
+      null,
+      {},
+      makeTokenStore(),
+      handleRefresh,
+    );
+    expect(result).toEqual({ shouldRetry: false, shouldReject: false });
+    expect(handleRefresh).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits on 401 when _retry is already true (no infinite loop)', async () => {
+    const handleRefresh = vi.fn();
+    const result = await applyResponseInterceptors(
+      new Response('', { status: 401 }),
+      null,
+      { _retry: true },
+      makeTokenStore(),
+      handleRefresh,
+    );
+    expect(result).toEqual({ shouldRetry: false, shouldReject: false });
+    expect(handleRefresh).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits on 401 when _skipAuthInterceptor is set', async () => {
+    const handleRefresh = vi.fn();
+    const result = await applyResponseInterceptors(
+      new Response('', { status: 401 }),
+      null,
+      { _skipAuthInterceptor: true },
+      makeTokenStore(),
+      handleRefresh,
+    );
+    expect(result).toEqual({ shouldRetry: false, shouldReject: false });
+    expect(handleRefresh).not.toHaveBeenCalled();
+  });
+
+  it('on 401 + refresh success: returns shouldRetry with the new token', async () => {
+    const handleRefresh = vi.fn().mockResolvedValue('new-token');
+    const tokenStore = makeTokenStore();
+    const result = await applyResponseInterceptors(
+      new Response('', { status: 401 }),
+      null,
+      {},
+      tokenStore,
+      handleRefresh,
+    );
+    expect(result).toEqual({ shouldRetry: true, shouldReject: false, newToken: 'new-token' });
+    expect(tokenStore.clear).not.toHaveBeenCalled();
+  });
+
+  it('on 401 + refresh failure: clears tokens, calls onUnauthorized, returns shouldReject', async () => {
+    const handleRefresh = vi.fn().mockResolvedValue(null);
+    const onUnauthorized = vi.fn();
+    const tokenStore = makeTokenStore();
+    const result = await applyResponseInterceptors(
+      new Response('', { status: 401 }),
+      null,
+      {},
+      tokenStore,
+      handleRefresh,
+      onUnauthorized,
+    );
+    expect(result).toEqual({ shouldRetry: false, shouldReject: true });
+    expect(tokenStore.clear).toHaveBeenCalledOnce();
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/utils/http/fetch-client/interceptors.ts
+++ b/src/lib/utils/http/fetch-client/interceptors.ts
@@ -1,18 +1,50 @@
 import { SAVE_AUTH_TOKENS } from '@/lib/config';
 import type { ExtendedRequestInit, InterceptorResult, TokenStore } from '@/types';
 
+import {
+  generateRequestId,
+  getCookieHeaderForRequest,
+  isValidRequestId,
+  REQUEST_ID_HEADER,
+} from '../shared';
+
+function hasHeader(headers: HeadersInit | undefined, name: string): boolean {
+  if (!headers) return false;
+  const lower = name.toLowerCase();
+  if (headers instanceof Headers) return headers.has(name);
+  if (Array.isArray(headers)) return headers.some(([k]) => k.toLowerCase() === lower);
+  return Object.keys(headers).some((k) => k.toLowerCase() === lower);
+}
+
 export async function applyRequestInterceptors(
   options: ExtendedRequestInit,
   tokenStore: TokenStore,
   defaultOptions: RequestInit,
 ): Promise<RequestInit> {
+  const mergedHeaders: Record<string, string> = {
+    ...(defaultOptions.headers as Record<string, string> | undefined),
+    ...(options.headers as Record<string, string> | undefined),
+  };
+
+  // Request-ID: send a fresh ID per call unless the caller supplied a valid one.
+  // Backend echoes whatever we send back to us when it matches its pattern.
+  const providedId =
+    mergedHeaders[REQUEST_ID_HEADER] ?? mergedHeaders[REQUEST_ID_HEADER.toLowerCase()];
+  if (!(providedId && isValidRequestId(providedId))) {
+    mergedHeaders[REQUEST_ID_HEADER] = generateRequestId();
+  }
+
+  // Cookie forwarding: a no-op in the browser (the cookie jar handles it);
+  // on the server we read next/headers and inject the Cookie header.
+  if (!hasHeader(mergedHeaders, 'cookie')) {
+    const cookieHeader = await getCookieHeaderForRequest();
+    if (cookieHeader) mergedHeaders.Cookie = cookieHeader;
+  }
+
   const mergedOptions: RequestInit = {
     ...defaultOptions,
     ...options,
-    headers: {
-      ...defaultOptions.headers,
-      ...options.headers,
-    },
+    headers: mergedHeaders,
   };
 
   if (options._skipAuthInterceptor) {
@@ -26,10 +58,7 @@ export async function applyRequestInterceptors(
   const token = directToken ?? (SAVE_AUTH_TOKENS ? await tokenStore.getAccessToken() : null);
 
   if (token) {
-    mergedOptions.headers = {
-      ...mergedOptions.headers,
-      Authorization: `Bearer ${token}`,
-    };
+    mergedHeaders.Authorization = `Bearer ${token}`;
   }
 
   return mergedOptions;
@@ -67,13 +96,4 @@ export async function applyResponseInterceptors(
     shouldReject: false,
     newToken,
   };
-}
-
-export function isBrowser(): boolean {
-  return typeof window !== 'undefined';
-}
-
-export function isEdgeRuntime(): boolean {
-  // @ts-expect-error - EdgeRuntime global is not in standard types
-  return typeof EdgeRuntime !== 'undefined';
 }

--- a/src/lib/utils/http/fetch-client/token-refresh.test.ts
+++ b/src/lib/utils/http/fetch-client/token-refresh.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TokenStore } from '@/types';
+
+import { REQUEST_ID_PATTERN } from '../shared';
+import { refreshAuthToken } from './token-refresh';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const SAVE_AUTH_TOKENS = { value: false };
+vi.mock('@/lib/config', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/config')>('@/lib/config');
+  return {
+    ...actual,
+    get SAVE_AUTH_TOKENS() {
+      return SAVE_AUTH_TOKENS.value;
+    },
+  };
+});
+
+function makeTokenStore(overrides: Partial<TokenStore> = {}): TokenStore {
+  return {
+    getAccessToken: vi.fn().mockResolvedValue(null),
+    saveAccessToken: vi.fn().mockResolvedValue(undefined),
+    getRefreshToken: vi.fn().mockResolvedValue(null),
+    saveRefreshToken: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('fetch refreshAuthToken', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    SAVE_AUTH_TOKENS.value = false;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('hits /auth/refresh (not /auth/refresh-token) and parses accessToken/refreshToken', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            accessToken: 'new-access',
+            refreshToken: 'new-refresh',
+            expiresIn: 900,
+            sessionId: 'sess-1',
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const result = await refreshAuthToken(makeTokenStore(), 'https://api.example.com/api/v1');
+
+    expect(result).toBe('new-access');
+    const [calledUrl] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe('https://api.example.com/api/v1/auth/refresh');
+  });
+
+  it('sends an X-Request-Id header matching the backend pattern', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            accessToken: 'a',
+            refreshToken: 'r',
+            expiresIn: 1,
+            sessionId: 's',
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    await refreshAuthToken(makeTokenStore(), 'https://api.example.com/api/v1');
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-Request-Id']).toMatch(REQUEST_ID_PATTERN);
+  });
+
+  it('cookie mode: does NOT send Authorization header', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: { accessToken: 'a', refreshToken: 'r', expiresIn: 1, sessionId: 's' },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    await refreshAuthToken(
+      makeTokenStore({ getRefreshToken: vi.fn().mockResolvedValue('stored-refresh') }),
+      'https://api.example.com/api/v1',
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it('bearer mode: sends Authorization: Bearer <refreshToken> and persists new tokens', async () => {
+    SAVE_AUTH_TOKENS.value = true;
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            accessToken: 'new-access',
+            refreshToken: 'new-refresh',
+            expiresIn: 900,
+            sessionId: 's',
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const store = makeTokenStore({
+      getRefreshToken: vi.fn().mockResolvedValue('stored-refresh'),
+    });
+
+    const result = await refreshAuthToken(store, 'https://api.example.com/api/v1');
+
+    expect(result).toBe('new-access');
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer stored-refresh');
+    expect(store.saveAccessToken).toHaveBeenCalledWith('new-access');
+    expect(store.saveRefreshToken).toHaveBeenCalledWith('new-refresh');
+  });
+
+  it('returns null on non-ok response', async () => {
+    fetchMock.mockResolvedValue(new Response('', { status: 401 }));
+    const result = await refreshAuthToken(makeTokenStore(), 'https://api.example.com/api/v1');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when fetch throws', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    const result = await refreshAuthToken(makeTokenStore(), 'https://api.example.com/api/v1');
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/utils/http/fetch-client/token-refresh.ts
+++ b/src/lib/utils/http/fetch-client/token-refresh.ts
@@ -1,22 +1,39 @@
 import { SAVE_AUTH_TOKENS } from '@/lib/config';
 import { AppApis } from '@/lib/config/app-apis';
 import { logger } from '@/lib/logger';
-import type { AuthTokens, TokenStore } from '@/types';
+import type { RefreshTokensResponse, TokenStore } from '@/types';
 
+import { generateRequestId, REQUEST_ID_HEADER } from '../shared';
+
+/**
+ * Call `POST /auth/refresh` to rotate the access/refresh token pair.
+ *
+ * Cookie-mode (default, `SAVE_AUTH_TOKENS=false`): the refresh token rides
+ * the `refresh` HttpOnly cookie set at login; we just need `credentials:
+ * 'include'`. Bearer-mode (`SAVE_AUTH_TOKENS=true`): we additionally send
+ * the stored refresh token as a Bearer header for non-browser callers.
+ *
+ * Backend response shape (`RefreshTokensResponseDto`):
+ *   { accessToken, refreshToken, expiresIn, sessionId }
+ * wrapped in the standard `{ data: ... }` envelope.
+ */
 export async function refreshAuthToken(
   tokenStore: TokenStore,
   baseURL: string,
 ): Promise<string | null> {
   try {
-    const currentRefreshToken = await tokenStore.getRefreshToken();
-    const refreshURL = `${baseURL}${AppApis.auth.refreshToken}`;
+    const refreshURL = `${baseURL}${AppApis.auth.refresh}`;
 
     const headers: HeadersInit = {
       'Content-Type': 'application/json',
+      [REQUEST_ID_HEADER]: generateRequestId(),
     };
 
-    if (currentRefreshToken) {
-      headers.Authorization = `Bearer ${currentRefreshToken}`;
+    if (SAVE_AUTH_TOKENS) {
+      const currentRefreshToken = await tokenStore.getRefreshToken();
+      if (currentRefreshToken) {
+        headers.Authorization = `Bearer ${currentRefreshToken}`;
+      }
     }
 
     const response = await fetch(refreshURL, {
@@ -24,7 +41,6 @@ export async function refreshAuthToken(
       headers,
       credentials: 'include',
       cache: 'no-store',
-      body: JSON.stringify({}),
     });
 
     if (!response.ok) {
@@ -32,15 +48,15 @@ export async function refreshAuthToken(
       return null;
     }
 
-    const data = await response.json();
-    const { access, refresh } = data.data as AuthTokens;
+    const body = (await response.json()) as { data: RefreshTokensResponse };
+    const { accessToken, refreshToken } = body.data;
 
     if (SAVE_AUTH_TOKENS) {
-      await tokenStore.saveAccessToken(access);
-      await tokenStore.saveRefreshToken(refresh);
+      await tokenStore.saveAccessToken(accessToken);
+      await tokenStore.saveRefreshToken(refreshToken);
     }
 
-    return access;
+    return accessToken;
   } catch (error) {
     logger.error({ err: error }, 'Token refresh failed');
     return null;

--- a/src/lib/utils/http/index.ts
+++ b/src/lib/utils/http/index.ts
@@ -1,3 +1,4 @@
 export { axiosClient, createAxiosClient } from './axios-client';
 export { createFetchClient, fetchClient } from './fetch-client';
+export { toSearchParams } from './shared';
 export * from './token-store';

--- a/src/lib/utils/http/shared/cookie-injection.test.ts
+++ b/src/lib/utils/http/shared/cookie-injection.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const isBrowserMock = vi.fn();
+vi.mock('./runtime', () => ({
+  isBrowser: () => isBrowserMock(),
+  isServer: () => !isBrowserMock(),
+}));
+
+const readServerCookieHeaderMock = vi.fn();
+vi.mock('./server-cookies', () => ({
+  readServerCookieHeader: () => readServerCookieHeaderMock(),
+}));
+
+// Import AFTER mocks so the module picks them up.
+const { getCookieHeaderForRequest } = await import('./cookie-injection');
+
+describe('getCookieHeaderForRequest', () => {
+  beforeEach(() => {
+    isBrowserMock.mockReset();
+    readServerCookieHeaderMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns undefined in the browser (no server-cookies import)', async () => {
+    isBrowserMock.mockReturnValue(true);
+
+    const result = await getCookieHeaderForRequest();
+
+    expect(result).toBeUndefined();
+    expect(readServerCookieHeaderMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the server cookie header when running on the server', async () => {
+    isBrowserMock.mockReturnValue(false);
+    readServerCookieHeaderMock.mockResolvedValue('session=abc; csrf=xyz');
+
+    const result = await getCookieHeaderForRequest();
+
+    expect(result).toBe('session=abc; csrf=xyz');
+    expect(readServerCookieHeaderMock).toHaveBeenCalledOnce();
+  });
+
+  it('returns undefined on the server when no cookies are present (empty string)', async () => {
+    isBrowserMock.mockReturnValue(false);
+    readServerCookieHeaderMock.mockResolvedValue('');
+
+    const result = await getCookieHeaderForRequest();
+
+    // Empty header serves no purpose — the helper normalises empty → undefined
+    // so callers don't have to special-case it.
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/lib/utils/http/shared/cookie-injection.ts
+++ b/src/lib/utils/http/shared/cookie-injection.ts
@@ -1,0 +1,21 @@
+import { isBrowser } from './runtime';
+
+/**
+ * Returns the `Cookie` header value to inject on outgoing requests, or
+ * `undefined` when no injection is needed.
+ *
+ * - **Browser:** returns `undefined`. The browser cookie jar attaches
+ *   cookies automatically when the request runs with `credentials: 'include'`
+ *   (fetch) or `withCredentials: true` (axios).
+ * - **Server (RSC / Server Action / Route Handler):** dynamically imports
+ *   the `server-only` helper to read `next/headers` and serialise the
+ *   incoming request's cookies. The dynamic import keeps `next/headers`
+ *   (and its `server-only` guard) out of the client bundle.
+ */
+export async function getCookieHeaderForRequest(): Promise<string | undefined> {
+  if (isBrowser()) return undefined;
+
+  const { readServerCookieHeader } = await import('./server-cookies');
+  const header = await readServerCookieHeader();
+  return header || undefined;
+}

--- a/src/lib/utils/http/shared/index.ts
+++ b/src/lib/utils/http/shared/index.ts
@@ -1,0 +1,12 @@
+export { getCookieHeaderForRequest } from './cookie-injection';
+export {
+  extractRequestIdFromHeaderRecord,
+  extractRequestIdFromHeaders,
+  generateRequestId,
+  isValidRequestId,
+  REQUEST_ID_HEADER,
+  REQUEST_ID_PATTERN,
+} from './request-id';
+export { parseApiError } from './response-parser';
+export { isBrowser, isServer } from './runtime';
+export { toSearchParams } from './search-params';

--- a/src/lib/utils/http/shared/request-id.test.ts
+++ b/src/lib/utils/http/shared/request-id.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractRequestIdFromHeaderRecord,
+  extractRequestIdFromHeaders,
+  generateRequestId,
+  isValidRequestId,
+  REQUEST_ID_PATTERN,
+} from './request-id';
+
+describe('request-id', () => {
+  it('generates IDs matching the backend pattern', () => {
+    for (let i = 0; i < 20; i++) {
+      const id = generateRequestId();
+      expect(id).toMatch(REQUEST_ID_PATTERN);
+    }
+  });
+
+  it('isValidRequestId accepts alphanumerics, dashes, underscores up to 128 chars', () => {
+    expect(isValidRequestId('abc-123_DEF')).toBe(true);
+    expect(isValidRequestId(generateRequestId())).toBe(true);
+    expect(isValidRequestId('a'.repeat(128))).toBe(true);
+
+    expect(isValidRequestId('')).toBe(false);
+    expect(isValidRequestId('has spaces')).toBe(false);
+    expect(isValidRequestId('has\nnewline')).toBe(false);
+    expect(isValidRequestId('a'.repeat(129))).toBe(false);
+    expect(isValidRequestId('inv@lid')).toBe(false);
+  });
+
+  it('extractRequestIdFromHeaders reads X-Request-Id case-insensitively', () => {
+    const headers = new Headers({ 'x-request-id': 'abc-123' });
+    expect(extractRequestIdFromHeaders(headers)).toBe('abc-123');
+  });
+
+  it('extractRequestIdFromHeaders ignores invalid values', () => {
+    const headers = new Headers({ 'X-Request-Id': 'has spaces' });
+    expect(extractRequestIdFromHeaders(headers)).toBeUndefined();
+  });
+
+  it('extractRequestIdFromHeaders returns undefined when missing', () => {
+    expect(extractRequestIdFromHeaders(new Headers())).toBeUndefined();
+    expect(extractRequestIdFromHeaders(undefined)).toBeUndefined();
+  });
+
+  it('extractRequestIdFromHeaderRecord handles plain objects (axios shape)', () => {
+    expect(extractRequestIdFromHeaderRecord({ 'X-Request-Id': 'abc-123' })).toBe('abc-123');
+    expect(extractRequestIdFromHeaderRecord({ 'x-request-id': 'abc-123' })).toBe('abc-123');
+    expect(extractRequestIdFromHeaderRecord({ 'X-Request-Id': ['abc-123', 'dup'] })).toBe(
+      'abc-123',
+    );
+    expect(extractRequestIdFromHeaderRecord({})).toBeUndefined();
+    expect(extractRequestIdFromHeaderRecord(undefined)).toBeUndefined();
+    expect(extractRequestIdFromHeaderRecord({ 'X-Request-Id': 'inv@lid' })).toBeUndefined();
+  });
+});

--- a/src/lib/utils/http/shared/request-id.ts
+++ b/src/lib/utils/http/shared/request-id.ts
@@ -1,0 +1,50 @@
+/**
+ * Request-ID propagation, mirroring the NestJS starter's
+ * `X-Request-Id` middleware.
+ *
+ * The backend accepts client-supplied IDs only when they match
+ * `REQUEST_ID_PATTERN` (alphanumeric/dash/underscore, ≤128 chars) — anything
+ * else is rejected and a fresh UUID is generated server-side. We send a
+ * compliant UUID per call by default so browser logs, frontend pino logs,
+ * and backend pino logs all share the same trace ID without server-side
+ * correlation work.
+ */
+
+export const REQUEST_ID_HEADER = 'X-Request-Id';
+
+export const REQUEST_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+export function isValidRequestId(value: string): boolean {
+  return REQUEST_ID_PATTERN.test(value);
+}
+
+/**
+ * Web Crypto `randomUUID()` is available in modern browsers, Node 19+,
+ * and the Edge runtime. UUIDs match `REQUEST_ID_PATTERN` so the backend
+ * will accept them verbatim.
+ */
+export function generateRequestId(): string {
+  return crypto.randomUUID();
+}
+
+/** Read `X-Request-Id` from a `Headers` instance, case-insensitively. */
+export function extractRequestIdFromHeaders(headers: Headers | undefined): string | undefined {
+  if (!headers) return undefined;
+  const value = headers.get(REQUEST_ID_HEADER);
+  return value && isValidRequestId(value) ? value : undefined;
+}
+
+/**
+ * Read `X-Request-Id` from a plain object (axios `error.response.headers`,
+ * which can be `Record<string, string | string[] | undefined>`).
+ */
+export function extractRequestIdFromHeaderRecord(
+  headers: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!headers) return undefined;
+  const key = Object.keys(headers).find((k) => k.toLowerCase() === REQUEST_ID_HEADER.toLowerCase());
+  if (!key) return undefined;
+  const raw = headers[key];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === 'string' && isValidRequestId(value) ? value : undefined;
+}

--- a/src/lib/utils/http/shared/response-parser.test.ts
+++ b/src/lib/utils/http/shared/response-parser.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiException } from '@/lib/errors';
+
+import { parseApiError } from './response-parser';
+
+describe('parseApiError', () => {
+  it('builds an ApiException from a well-formed backend error envelope', () => {
+    const err = parseApiError(
+      {
+        status: 422,
+        path: '/api/v1/users',
+        message: 'Validation failed',
+        code: 'VALIDATION_ERROR',
+        errors: [{ email: 'Invalid format' }],
+        requestId: 'req-abc',
+      },
+      422,
+    );
+
+    expect(err).toBeInstanceOf(ApiException);
+    expect(err.status).toBe(422);
+    expect(err.message).toBe('Validation failed');
+    expect(err.code).toBe('VALIDATION_ERROR');
+    expect(err.requestId).toBe('req-abc');
+    expect(err.getErrorMessage('email')).toBe('Invalid format');
+  });
+
+  it('falls back to the response request-id when the body has none', () => {
+    const err = parseApiError({ message: 'Boom' }, 500, 'req-from-header');
+    expect(err.requestId).toBe('req-from-header');
+  });
+
+  it('prefers the body request-id over the header value', () => {
+    const err = parseApiError(
+      { message: 'Boom', requestId: 'req-from-body' },
+      500,
+      'req-from-header',
+    );
+    expect(err.requestId).toBe('req-from-body');
+  });
+
+  it('uses fallback status when body has none', () => {
+    const err = parseApiError({ message: 'Network blip' }, 503);
+    expect(err.status).toBe(503);
+  });
+
+  it('handles non-object bodies gracefully', () => {
+    const err = parseApiError(null, 500);
+    expect(err.status).toBe(500);
+    expect(err.message).toBe('Request failed with status 500');
+  });
+
+  it('preserves stack when provided', () => {
+    const err = parseApiError({ message: 'x' }, 500, undefined, 'fake-stack');
+    expect(err.stack).toBe('fake-stack');
+  });
+});

--- a/src/lib/utils/http/shared/response-parser.ts
+++ b/src/lib/utils/http/shared/response-parser.ts
@@ -1,0 +1,49 @@
+import { ApiException } from '@/lib/errors';
+
+/**
+ * Build an `ApiException` from a backend error response body.
+ *
+ * Both HTTP clients used to inline this parsing — every change to the error
+ * envelope (e.g. adding `requestId`) had to be made twice and inevitably
+ * drifted. This is the single source of truth.
+ *
+ * `responseRequestId` is the value read from the `X-Request-Id` response
+ * header. It's used as a fallback when the error body didn't carry one
+ * (e.g. when the backend rejected the request before the exception filter
+ * stamped the envelope).
+ */
+export function parseApiError(
+  body: unknown,
+  fallbackStatus: number,
+  responseRequestId?: string,
+  stack?: string,
+): ApiException {
+  const safeBody = (typeof body === 'object' && body !== null ? body : {}) as Record<
+    string,
+    unknown
+  >;
+
+  const exception = ApiException.fromResponse(
+    {
+      status: typeof safeBody.status === 'number' ? safeBody.status : fallbackStatus,
+      message:
+        typeof safeBody.message === 'string'
+          ? safeBody.message
+          : `Request failed with status ${fallbackStatus}`,
+      code: typeof safeBody.code === 'string' ? safeBody.code : undefined,
+      errors: Array.isArray(safeBody.errors)
+        ? (safeBody.errors as Record<string, string>[])
+        : undefined,
+      data:
+        typeof safeBody.data === 'object' && safeBody.data !== null
+          ? (safeBody.data as Record<string, unknown>)
+          : undefined,
+      path: typeof safeBody.path === 'string' ? safeBody.path : undefined,
+      requestId: typeof safeBody.requestId === 'string' ? safeBody.requestId : responseRequestId,
+    },
+    fallbackStatus,
+  );
+
+  if (stack) exception.stack = stack;
+  return exception;
+}

--- a/src/lib/utils/http/shared/runtime.test.ts
+++ b/src/lib/utils/http/shared/runtime.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { isBrowser, isServer } from './runtime';
+
+describe('runtime detection', () => {
+  // Vitest runs with `environment: 'jsdom'`, so `window` is defined and
+  // we should detect "browser". This guards against accidental regressions
+  // (e.g. swapping the implementation to typeof document, which jsdom also
+  // sets, but which subtly differs in edge runtimes).
+  it('detects browser environment under jsdom', () => {
+    expect(isBrowser()).toBe(true);
+    expect(isServer()).toBe(false);
+  });
+
+  it('isServer is the inverse of isBrowser', () => {
+    expect(isServer()).toBe(!isBrowser());
+  });
+});

--- a/src/lib/utils/http/shared/runtime.ts
+++ b/src/lib/utils/http/shared/runtime.ts
@@ -1,0 +1,12 @@
+/**
+ * Runtime detection used by the HTTP clients to decide whether to forward
+ * cookies explicitly (server) or rely on the browser's credentialed-fetch
+ * behaviour (client).
+ *
+ * Keep this module side-effect-free and trivially small so it tree-shakes
+ * cleanly into both the browser bundle and the server bundle.
+ */
+
+export const isBrowser = (): boolean => typeof window !== 'undefined';
+
+export const isServer = (): boolean => !isBrowser();

--- a/src/lib/utils/http/shared/search-params.test.ts
+++ b/src/lib/utils/http/shared/search-params.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { toSearchParams } from './search-params';
+
+describe('toSearchParams', () => {
+  it('serialises a typed query object to URLSearchParams', () => {
+    const params = toSearchParams({ page: 2, size: 20, sort: 'createdAt', order: 'desc' });
+    expect(params.toString()).toBe('page=2&size=20&sort=createdAt&order=desc');
+  });
+
+  it('skips undefined, null, and empty strings (lets backend defaults win)', () => {
+    const params = toSearchParams({
+      page: 1,
+      size: undefined,
+      search: '',
+      sort: null as unknown as string,
+    });
+    expect(params.toString()).toBe('page=1');
+  });
+
+  it('repeats keys for array values', () => {
+    const params = toSearchParams({ tag: ['a', 'b', 'c'] });
+    expect(params.toString()).toBe('tag=a&tag=b&tag=c');
+  });
+
+  it('skips empty array items', () => {
+    const params = toSearchParams({ tag: ['a', '', null, 'b'] as Array<string | null> });
+    expect(params.toString()).toBe('tag=a&tag=b');
+  });
+
+  it('stringifies booleans and numbers', () => {
+    const params = toSearchParams({ active: true, count: 0 });
+    expect(params.toString()).toBe('active=true&count=0');
+  });
+});

--- a/src/lib/utils/http/shared/search-params.ts
+++ b/src/lib/utils/http/shared/search-params.ts
@@ -1,0 +1,38 @@
+/**
+ * Build a `URLSearchParams` instance from a typed query object.
+ *
+ * Skips keys whose value is `undefined`, `null`, or an empty string so
+ * defaults stay implicit (the backend's `BaseQueryDto` has its own defaults
+ * — sending empty strings would override them). Coerces numbers/booleans
+ * to strings, leaves strings untouched, and serialises arrays as repeated
+ * keys (`?tag=a&tag=b`) — the encoding `qs.stringify` / NestJS' parser
+ * round-trips natively.
+ *
+ * Use with a typed query interface so the call site reads as a single
+ * structured object instead of a string-bag:
+ *
+ * ```ts
+ * const result = await fetchClient.get<PaginatedApiResponse<User>>(
+ *   `/users?${toSearchParams<UsersQuery>(query)}`,
+ * );
+ * ```
+ */
+export function toSearchParams<T extends Record<string, unknown>>(params: T): URLSearchParams {
+  const out = new URLSearchParams();
+
+  for (const [key, raw] of Object.entries(params)) {
+    if (raw === undefined || raw === null || raw === '') continue;
+
+    if (Array.isArray(raw)) {
+      for (const item of raw) {
+        if (item === undefined || item === null || item === '') continue;
+        out.append(key, String(item));
+      }
+      continue;
+    }
+
+    out.append(key, String(raw));
+  }
+
+  return out;
+}

--- a/src/lib/utils/http/shared/server-cookies.ts
+++ b/src/lib/utils/http/shared/server-cookies.ts
@@ -1,0 +1,20 @@
+import 'server-only';
+
+import { cookies } from 'next/headers';
+
+/**
+ * Serialise the incoming request's cookies into a single `Cookie` header
+ * suitable for forwarding to the backend from a Server Component, Server
+ * Action, or Route Handler.
+ *
+ * `credentials: 'include'` (fetch) and `withCredentials: true` (axios) are
+ * browser-only concepts; on the server there is no cookie jar, so the
+ * backend's HttpOnly session cookies never reach it unless we attach them
+ * explicitly. This helper is the only place that touches `next/headers` —
+ * the `server-only` import prevents accidental client-component usage.
+ */
+export async function readServerCookieHeader(): Promise<string> {
+  const all = (await cookies()).getAll();
+  if (all.length === 0) return '';
+  return all.map((c) => `${c.name}=${c.value}`).join('; ');
+}

--- a/src/types/common/api.types.ts
+++ b/src/types/common/api.types.ts
@@ -13,6 +13,11 @@ export interface ApiResponse<T> {
 /**
  * Error envelope returned by the API on failure. Surfaced on the client as
  * an `ApiException` by the HTTP clients.
+ *
+ * Note: the backend's error envelope does **not** include `timestamp` (only
+ * the success envelope does); it's optional here for that reason.
+ * `requestId` is set when the backend's request-correlation middleware
+ * generated/accepted one for the failed request.
  */
 export interface ApiErrorResponse {
   status: number;
@@ -21,7 +26,8 @@ export interface ApiErrorResponse {
   code?: string;
   errors?: Record<string, string>[];
   data?: Record<string, unknown>;
-  timestamp: string;
+  requestId?: string;
+  timestamp?: string;
 }
 
 /** Offset-based pagination metadata. */

--- a/src/types/common/auth.types.ts
+++ b/src/types/common/auth.types.ts
@@ -1,4 +1,26 @@
-export interface AuthTokens {
-  access: string;
-  refresh: string;
+/**
+ * Auth payload shapes returned by the backend.
+ *
+ * Mirrors `AuthResponseDto` / `RefreshTokensResponseDto` in the NestJS starter
+ * (`src/modules/auth/dto/auth-response.dto.ts`). Keep field names in sync.
+ */
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  username: string;
+  isEmailVerified: boolean;
 }
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  sessionId: string;
+}
+
+export interface AuthResponse extends AuthTokens {
+  user: AuthUser;
+}
+
+export type RefreshTokensResponse = AuthTokens;

--- a/src/types/common/http.types.ts
+++ b/src/types/common/http.types.ts
@@ -1,9 +1,21 @@
 export type DataKey = string | null;
 
+/**
+ * Shape accepted by both clients' `params` option. Serialised via
+ * `toSearchParams` so keys with `undefined`/`null`/`''` values are skipped
+ * (lets backend defaults win) and array values become repeated keys.
+ */
+export type QueryParams = Record<string, unknown>;
+
 declare module 'axios' {
   export interface AxiosRequestConfig {
     _retry?: boolean;
     _skipAuthInterceptor?: boolean;
+    // Note: `params` is declared on AxiosRequestConfig natively as `any`.
+    // We don't re-declare it here (module augmentation can only widen, not
+    // narrow). Both clients' `paramsSerializer` runs all params through
+    // `toSearchParams`, so the runtime contract matches `QueryParams`
+    // regardless of the compile-time type.
   }
 }
 
@@ -19,6 +31,13 @@ export interface AxiosClientOptions {
   baseURL?: string;
   onUnauthorized?: () => void;
   tokenStore: TokenStore;
+  /**
+   * Headers merged into `axios.create({ headers })`. Use for static defaults
+   * that should apply to every request from this client (e.g. an API-version
+   * header). Per-request `Cookie` injection is handled by the interceptor,
+   * not here.
+   */
+  defaultHeaders?: Record<string, string>;
 }
 
 export interface FetchClientOptions {
@@ -33,6 +52,11 @@ export interface ExtendedRequestInit extends RequestInit {
   _retry?: boolean;
   _skipAuthInterceptor?: boolean;
   _authToken?: string;
+  /**
+   * Typed query params. Appended to the URL via `toSearchParams` after
+   * any literal `?...` already in the path. Skips `undefined`/`null`/`''`.
+   */
+  params?: QueryParams;
 }
 
 export interface InterceptorResult {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5355,6 +5355,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"server-only@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "server-only@npm:0.0.1"
+  checksum: 10c0/4704f0ef85da0be981af6d4ed8e739d39bcfd265b9c246a684060acda5642d0fdc6daffc2308e71e2682c5f508090978802eae0a77623c9b90a49f9ae68048d6
+  languageName: node
+  linkType: hard
+
 "sharp@npm:^0.34.5":
   version: 0.34.5
   resolution: "sharp@npm:0.34.5"
@@ -5774,6 +5781,7 @@ __metadata:
     react-secure-storage: "npm:^1.3.2"
     redux: "npm:^5.0.1"
     redux-persist: "npm:^6.0.0"
+    server-only: "npm:^0.0.1"
     tailwindcss: "npm:^4.3.0"
     tsx: "npm:^4.22.0"
     typescript: "npm:^6.0.3"


### PR DESCRIPTION
## Summary

Aligns the dual HTTP clients (`fetchClient` + `axiosClient`) with the NestJS-starter backend contract end-to-end. Both clients now share a DRY foundation that handles cookie forwarding (CSR + RSC), request-id correlation, error parsing, and typed query serialisation symmetrically — no more "axios does this, fetch doesn't" drift.

- **Endpoints fixed:** `/auth/refresh-token` → `/auth/refresh`; added `login`, `logout`, `me`, `capabilities` to `AppApis`. Frontend-owned `API_PREFIX = '/api/v1'` so the version segment lives in code, not env.
- **Bare-origin env:** `NEXT_PUBLIC_API_URL` is the host only; `/api/v{n}` is appended via `getApiBaseUrl()` with defensive suffix stripping + warning.
- **Camel-case token contract:** `accessToken`, `refreshToken`, `expiresIn`, `sessionId` (was `access`/`refresh`). Added `AuthUser`, `AuthResponse`, `RefreshTokensResponse`.
- **`ApiException.requestId`** sourced from response header or error body — instant cross-stack tracing.
- **Shared foundation** (`src/lib/utils/http/shared/`): `runtime`, `server-cookies` (server-only), `cookie-injection` (runtime-aware, dynamic-imports next/headers so it stays off the client bundle), `request-id` (UUIDs matching backend `REQUEST_ID_PATTERN`), `response-parser`, `search-params`.
- **Typed `params` option** on both clients replaces `?${string}` concat. Axios `paramsSerializer` overridden so both clients produce byte-identical query strings.
- **Default cookie-mode auth** (`SAVE_AUTH_TOKENS = false`); bearer-mode is a one-flag flip — both backed by the same backend dual extractor.
- **`server-only`** added as a dependency (Next 16 dropped the transitive).

## Test plan

- [x] `yarn ci:check` — Biome lint + format + import sort
- [x] `yarn type-check`
- [x] `yarn check:deprecated`
- [x] `yarn test` — 84 tests across 12 files (47 new this PR)
- [x] `yarn build` — production build green
- [x] Pre-commit + pre-push hooks pass
- [ ] Smoke test against a running NestJS-starter backend (cookie-mode login → refresh → me)
- [ ] CI green

## Out of scope (deliberate)

Login/logout/me service code, MFA / passkey / OAuth / sudo flows, CSRF, WebSocket client, auth Redux slice, filling `features/auth` and `features/dashboard` scaffolding. The HTTP layer is now correct against the backend; whoever builds an app on top of this template can wire those in without touching transport-level concerns.

## Docs

- `src/lib/utils/http/README.md` — full rewrite with TL;DR, module diagram, Configuration moved above usage, SSR/request-id sections, typed-query patterns.
- `README.md` — HTTP feature blurb + `NEXT_PUBLIC_API_URL` row updated.
- `docs/structure.md` — `shared/` tree added, `api-url.ts` added, annotations clarified.