### PR TITLE
feat(ws): backend-compatible WebSocket client with hooks + Redux slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A production-ready, feature-packed starter template for Next.js applications. Bu
 - **i18n** — `next-intl` with locale-scoped routes under `src/app/[locale]/`, server-configured `timeZone` to avoid hydration mismatches.
 - **State** — Redux Toolkit + redux-persist with a per-request store (`useRef`-based), SSR-safe storage (`src/store/storage.ts`), and `preloadedState` support for Server Component → Redux hydration.
 - **HTTP** — dual clients (`fetchClient` + `axiosClient`) on a shared foundation (`src/lib/utils/http/shared/`): runtime-aware cookie forwarding (browser jar in CSR, `next/headers` injection in RSC), automatic `X-Request-Id` correlation with the backend, single `parseApiError` error pipeline, cookie-mode auth by default with a one-flag flip to bearer-mode. Backend-compatible response envelope, pagination (offset + cursor), and base query types ship out of the box.
+- **WebSocket** — typed Socket.IO client (`src/lib/utils/ws/`) matching the NestJS-starter `/ws` gateway: cookie or bearer auth (reuses `SAVE_AUTH_TOKENS`), application-level heartbeat, reconnection with `auth:force:disconnect` policy enforcement (server-flagged `reconnectable` boolean), public/anonymous mode opt-in, Redux slice for connection state (not persisted), three hooks (`useWsStatus`, `useWsEvent`, `useWsEmit`) with lazy connect, hard SSR boundary.
 - **Env validation** — zod-validated, cached at module load (`src/lib/env/`). Add a variable in one place and type-safety, validation, and coercion flow everywhere.
 - **Logger** — pino with env-aware transports (pretty in dev, JSON to stdout in prod, silent in test) and automatic redaction of tokens / passwords / auth headers.
 - **Theme** — `@teispace/next-themes` (drop-in replacement for the unmaintained `next-themes`).
@@ -53,6 +54,7 @@ For deeper detail see `docs/structure.md`, `src/features/README.md`, and `src/i1
 - **[Feature-Based Architecture](src/features/README.md)** — how features are organized and how to add new ones.
 - **[Internationalization (i18n)](src/i18n/README.md)** — using translations, adding locales, routing.
 - **[HTTP Client](src/lib/utils/http/README.md)** — `fetchClient` / `axiosClient` usage guide.
+- **[WebSocket Client](src/lib/utils/ws/README.md)** — `wsClient` + React hooks for the backend's `/ws` gateway.
 - **[Changelog](CHANGELOG.md)** — notable changes.
 
 ## 🏗️ Architecture

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -126,6 +126,35 @@ nextjs-starter/
 │   │   │   │   ├── index.ts                    # Public surface: fetchClient, axiosClient, toSearchParams
 │   │   │   │   ├── token-store.ts              # secureStorageTokenStore (inert in cookie-mode)
 │   │   │   │   └── README.md
+│   │   │   ├── ws/                             # WebSocket client (Socket.IO, /ws gateway)
+│   │   │   │   ├── types/                      # Backend-mirrored event maps + payload shapes
+│   │   │   │   │   ├── events.ts               # ClientToServerEvents, ServerToClientEvents
+│   │   │   │   │   ├── payloads.ts             # WsErrorPayload, WsTokenRenewedPayload, etc.
+│   │   │   │   │   ├── disconnect-reason.ts    # WsDisconnectReason + isReconnectableReason
+│   │   │   │   │   └── index.ts
+│   │   │   │   ├── shared/                     # Internal: runtime, auth-carrier, URL composer
+│   │   │   │   │   ├── runtime.ts              # isBrowser + WsSsrError (hard SSR guard)
+│   │   │   │   │   ├── auth-carrier.ts         # buildHandshakeAuth (cookie vs bearer)
+│   │   │   │   │   ├── ws-url.ts               # getWsUrl (origin + namespace)
+│   │   │   │   │   └── index.ts
+│   │   │   │   ├── client/                     # WsClient class + default singleton
+│   │   │   │   │   ├── ws-client.ts            # Lifecycle, heartbeat, force-disconnect
+│   │   │   │   │   ├── client.ts               # `wsClient` lazy proxy singleton
+│   │   │   │   │   ├── lifecycle-emitter.ts    # Internal typed event emitter
+│   │   │   │   │   ├── types.ts                # WsStatus, WsClientOptions, WsConnectOptions
+│   │   │   │   │   └── index.ts
+│   │   │   │   ├── redux/                      # Bridge + selectors (slice lives in store/slices)
+│   │   │   │   │   ├── bridge.ts               # attachWsBridge — only path that dispatches to ws slice
+│   │   │   │   │   ├── selectors.ts            # selectWsStatus, selectWsIsConnected, ...
+│   │   │   │   │   └── index.ts
+│   │   │   │   ├── hooks/                      # React hooks
+│   │   │   │   │   ├── use-ws-status.ts        # Read connection state from Redux
+│   │   │   │   │   ├── use-ws-event.ts         # Subscribe with lazy connect on first mount
+│   │   │   │   │   ├── use-ws-emit.ts          # Typed emit accessor
+│   │   │   │   │   └── index.ts
+│   │   │   │   ├── constants.ts                # WS_NAMESPACE, WS_HEARTBEAT_INTERVAL_MS, etc.
+│   │   │   │   ├── index.ts                    # Public surface
+│   │   │   │   └── README.md
 │   │   │   └── index.ts
 │   │   └── validations/
 │   │       └── index.ts
@@ -147,7 +176,9 @@ nextjs-starter/
 │   │   ├── hooks.ts                            # Typed Redux hooks
 │   │   ├── index.ts                            # makeStore (accepts preloadedState)
 │   │   ├── persistor.ts                        # Redux-persist setup
-│   │   ├── rootReducer.ts                      # Root reducer
+│   │   ├── rootReducer.ts                      # Root reducer (ws slice NOT persisted)
+│   │   ├── slices/
+│   │   │   └── ws.slice.ts                     # WebSocket connection state (ephemeral)
 │   │   └── storage.ts                          # SSR-safe storage (noop on server, localStorage on client)
 │   │
 │   ├── styles/

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "redux": "^5.0.1",
     "redux-persist": "^6.0.0",
     "server-only": "^0.0.1",
+    "socket.io-client": "^4.8.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/lib/utils/ws/README.md
+++ b/src/lib/utils/ws/README.md
@@ -22,16 +22,20 @@ Feature code imports from `@/lib/utils/ws` only. `shared/`, `redux/bridge`, and 
 - [Quick start](#quick-start)
 - [Configuration](#configuration)
 - [Architecture](#architecture)
-- [Authentication](#authentication)
-- [Hooks](#hooks)
-- [Lifecycle & reconnection](#lifecycle--reconnection)
-- [Force-disconnect (server-initiated)](#force-disconnect-server-initiated)
-- [Heartbeat](#heartbeat)
-- [Token renewal](#token-renewal)
-- [Presence](#presence)
-- [Public / anonymous connections](#public--anonymous-connections)
-- [SSR boundary](#ssr-boundary)
-- [Adding custom events](#adding-custom-events)
+- [In-depth usage guide](#in-depth-usage-guide)
+  - [Authentication modes](#authentication-modes)
+  - [Connection lifecycle in practice](#connection-lifecycle-in-practice)
+  - [Listening to server events](#listening-to-server-events)
+  - [Sending events to the server](#sending-events-to-the-server)
+  - [Reading and reacting to connection state](#reading-and-reacting-to-connection-state)
+  - [Presence (online/offline tracking)](#presence-onlineoffline-tracking)
+  - [Handling server-initiated disconnects](#handling-server-initiated-disconnects)
+  - [Public / anonymous flows](#public--anonymous-flows)
+  - [Multi-namespace apps](#multi-namespace-apps)
+  - [Adding custom feature events](#adding-custom-feature-events)
+  - [Imperative use outside React](#imperative-use-outside-react)
+  - [Cleanup on logout](#cleanup-on-logout)
+  - [Testing components that use the WS layer](#testing-components-that-use-the-ws-layer)
 - [API reference](#api-reference)
 - [Troubleshooting](#troubleshooting)
 - [Related docs](#related-docs)
@@ -43,6 +47,7 @@ Feature code imports from `@/lib/utils/ws` only. `shared/`, `redux/bridge`, and 
 ```tsx
 'use client';
 
+import { useEffect } from 'react';
 import { useWsEvent, useWsEmit, useWsStatus } from '@/lib/utils/ws';
 
 export function PresenceWidget({ userId }: { userId: string }) {
@@ -50,7 +55,8 @@ export function PresenceWidget({ userId }: { userId: string }) {
   const emit = useWsEmit();
 
   useEffect(() => {
-    if (isConnected) emit('presence:subscribe', { userId });
+    if (!isConnected) return;
+    emit('presence:subscribe', { userId });
     return () => { emit('presence:unsubscribe', { userId }); };
   }, [isConnected, userId, emit]);
 
@@ -128,177 +134,422 @@ All defaults match the backend's documented defaults (`nestjs-starter/docs/socke
 
 ---
 
-## Authentication
+## In-depth usage guide
 
-### Cookie-mode (default)
+This section walks through every realistic scenario you'll hit. Read top-to-bottom on your first integration, or jump to a specific subsection later.
 
-`SAVE_AUTH_TOKENS = false`. The browser cookie jar carries the `access` HttpOnly cookie on the Socket.IO handshake automatically — the backend's three-source extractor reads it from `handshake.headers.cookie`. **No auth payload is sent.** Tokens never touch JavaScript.
+### Authentication modes
 
-### Bearer-mode
+The WS layer reuses the HTTP layer's `SAVE_AUTH_TOKENS` flag (in `src/lib/config/constants.ts`). Pick one mode for the whole app — mixing per-request makes the auth surface much harder to reason about.
 
-`SAVE_AUTH_TOKENS = true`. The client reads the access token from `secureStorageTokenStore` and sends it as `handshake.auth.token`. The backend extracts it first (priority 1 over cookie). If no token is stored, `connect()` rejects with `WS_AUTH_REQUIRED` before opening the socket.
+#### Cookie-mode (default, `SAVE_AUTH_TOKENS = false`)
 
-Both modes work transparently against the same backend — the only difference is where the token rides.
+After the user logs in via HTTP, the backend sets an HttpOnly `access` cookie. When you call `wsClient.connect()`, the browser cookie jar attaches that cookie to the Socket.IO handshake automatically. The backend's three-source token extractor (auth payload → Authorization header → cookie) reads it and authenticates the socket.
 
----
+You write **no auth-related code** in cookie-mode. Just `useWsEvent` or `wsClient.connect()` and the rest happens transparently.
 
-## Hooks
+```tsx
+'use client';
 
-### `useWsStatus()`
+import { useWsEvent } from '@/lib/utils/ws';
 
-Read-only window onto the connection. Each field is a separate selector so components only re-render when their own datum changes.
+export function Notifications() {
+  // The browser cookie does all the auth work. Just subscribe.
+  useWsEvent('error', (err) => console.error(err));
+  return null;
+}
+```
+
+**Limitation in v1:** tokens never touch JS, so the frontend can't drive in-place `auth:token:renew` (the backend handler expects the refresh token in the payload). When the access token expires the socket disconnects, then reconnects with a fresh access cookie that the HTTP layer refreshed on a parallel API call. One sub-second blip; users almost never notice.
+
+#### Bearer-mode (`SAVE_AUTH_TOKENS = true`)
+
+Flip the flag. Now the WS client reads the access token from `secureStorageTokenStore` (`react-secure-storage` wrapper) and sends it as `handshake.auth.token`. The backend's extractor picks that up with highest priority — same code path, different carrier.
+
+Bearer-mode is useful when:
+- You're targeting React Native or a webview where cookies don't behave the same way.
+- You're integrating with a backend that's CORS-restricted enough that cookie credentials don't flow.
+- You need to debug auth by inspecting the token in DevTools.
+
+If `SAVE_AUTH_TOKENS = true` and no token is stored, `wsClient.connect()` rejects with `WS_AUTH_REQUIRED` **before** opening the socket — you don't get a misleading silent failure.
 
 ```ts
-const {
-  status,                  // 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'disconnected'
-  isConnected,             // boolean
-  isDisconnectedFatally,   // true when server sent reconnectable=false
-  socketId,                // current socket id, or null
-  lastError,               // last WsErrorPayload, or null
-  forceDisconnectReason,   // WsDisconnectReason | null
-  reconnectable,           // boolean | null
-} = useWsStatus();
+// After a successful HTTP login that stored the tokens:
+await wsClient.connect();
+// Or if you don't care about the success/failure boundary:
+wsClient.connect().catch(() => { /* the lifecycle emitter already reported */ });
 ```
 
-### `useWsEvent(event, handler)`
+#### Anonymous mode (no auth at all)
 
-Subscribe to a server-emitted event. The handler is captured by ref, so passing an inline arrow doesn't cause re-subscriptions on every render. Only `event` is a real dependency.
-
-```tsx
-useWsEvent('presence:online', ({ userId, timestamp }) => {
-  // typed automatically from ServerToClientEvents
-});
-```
-
-**Triggers a lazy connect** on first subscriber. Subsequent subscriptions reuse the open socket.
-
-### `useWsEmit()`
-
-Returns a stable, fully-typed emit function. Returns `false` if the socket isn't connected yet.
-
-```tsx
-const emit = useWsEmit();
-emit('presence:subscribe', { userId });   // type-checked against ClientToServerEvents
-```
-
----
-
-## Lifecycle & reconnection
-
-| Status | Meaning |
-|---|---|
-| `idle` | No connection attempt yet. |
-| `connecting` | Initial connect in flight. |
-| `connected` | Socket open, handshake accepted, ready to send/receive. |
-| `reconnecting` | Transport closed unexpectedly; socket.io-client is retrying (exponential backoff capped at 10 s). |
-| `disconnected` | Explicitly disconnected, or the server force-disconnected with `reconnectable: false`. |
-
-Socket.IO drives reconnection automatically for network failures (`transport close`, `ping timeout`). The client respects the server's `reconnectable` flag — when the backend sends `auth:force:disconnect` with `reconnectable: false`, auto-reconnect is **disabled** until you call `connect()` explicitly. This prevents login-loop storms after session revocation.
-
----
-
-## Force-disconnect (server-initiated)
-
-The backend emits `auth:force:disconnect` with `{ reason, reconnectable }`. **Branch on `reconnectable`, not `reason`.**
-
-| `reason` | `reconnectable` | UI guidance |
-|---|---|---|
-| `session_revoked` | `false` | Show "signed out elsewhere"; route to login |
-| `max_connections` | `false` | Show "device limit reached"; suggest closing other tabs |
-| `rate_limited` | `false` | Show "too many connection attempts"; back off ~60 s |
-| `roles_changed` | `true` | Reconnect happens transparently — new handshake pulls fresh permissions |
-| `max_age` | `true` | Reconnect happens transparently |
-| `server_shutdown` | `true` | Reconnect happens transparently — lands on a healthy node |
-
-The Redux slice exposes both `forceDisconnectReason` and `reconnectable`; the helper `selectWsIsDisconnectedFatally` checks `reconnectable === false`.
-
-```tsx
-const { isDisconnectedFatally, forceDisconnectReason } = useWsStatus();
-
-useEffect(() => {
-  if (isDisconnectedFatally && forceDisconnectReason === 'session_revoked') {
-    router.push('/login');
-  }
-}, [isDisconnectedFatally, forceDisconnectReason]);
-```
-
----
-
-## Heartbeat
-
-The client sends `ping` every 25 s to refresh the backend's Redis socket-metadata TTL (default 120 s server-side) and trigger a roles-version check. This is **separate** from socket.io's engine.io ping — both run. Heartbeat starts on `connect` and stops on `disconnect`; you don't manage it.
-
-If you change `WS_HEARTBEAT_INTERVAL_MS`, also change the backend's `WS_SOCKET_TTL_SECONDS` to stay > interval × 4.
-
----
-
-## Token renewal
-
-**Cookie-mode (default): not implemented in v1.** When the access token nears expiry, the socket disconnects and reconnects — the browser cookie jar supplies a fresh access cookie on the new handshake (refreshed by the HTTP layer on the next API call). One sub-second blip near token expiry.
-
-**Bearer-mode:** Future work. The backend supports in-place `auth:token:renew` (rate-limited to 5/min) but the v1 client doesn't schedule it. Subscribe to `auth:token:renewed` if you implement renewal yourself, and call `wsClient.emit('auth:token:renew', { refreshToken })` ahead of expiry.
-
----
-
-## Presence
-
-Backend tracks online/offline state in Redis. To watch a specific user:
-
-```tsx
-const emit = useWsEmit();
-
-useEffect(() => {
-  emit('presence:subscribe', { userId });
-  return () => { emit('presence:unsubscribe', { userId }); };
-}, [userId, emit]);
-
-useWsEvent('presence:status', ({ userId: uid, status, lastSeen }) => {
-  /* initial snapshot for `uid` */
-});
-
-useWsEvent('presence:online',  ({ userId: uid }) => { /* uid came online */ });
-useWsEvent('presence:offline', ({ userId: uid }) => { /* uid went offline */ });
-```
-
-Cap: 50 subscriptions per socket (backend-enforced).
-
----
-
-## Public / anonymous connections
-
-The backend supports unauthenticated sockets — they only reach `@WsPublic()` handlers (currently `ping`, `presence:subscribe`, `presence:unsubscribe`). To opt in:
+Opt-in per-call. The backend admits the connection up to a global cap (`WS_MAX_ANONYMOUS_SOCKETS = 10_000` server-side). Only handlers decorated with `@WsPublic()` are reachable — currently `ping`, `presence:subscribe`, `presence:unsubscribe`.
 
 ```ts
 await wsClient.connect({ anonymous: true });
 ```
 
-The handshake is sent without an auth payload and without a cookie. The backend admits the connection up to a global cap (`WS_MAX_ANONYMOUS_SOCKETS`, default 10,000).
+Use this when you want a public-presence widget on a landing page or a "currently online" badge without forcing visitors to sign in.
 
-Default is `anonymous: false` — connect refuses in bearer-mode without a token; cookie-mode optimistically connects and the server rejects if the cookie is missing.
+### Connection lifecycle in practice
 
----
+Most apps never call `connect()` explicitly — the hooks lazy-trigger it. But there are a few cases where you'll want explicit control:
 
-## SSR boundary
+```tsx
+'use client';
 
-Opening a WebSocket from a Server Component is **always** a bug — there's no client to listen on the other end. The WS layer throws `WsSsrError` instead of silently no-op'ing:
+import { useEffect } from 'react';
+import { wsClient } from '@/lib/utils/ws';
+
+// 1. Connect after auth is known to be ready (avoids racing with login flow):
+export function AppShell() {
+  const { isLoggedIn } = useAuth();
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    wsClient.connect().catch(() => {/* state is mirrored to Redux already */});
+    return () => wsClient.disconnect();
+  }, [isLoggedIn]);
+
+  return <Layout />;
+}
+
+// 2. Connect anonymously for public pages, upgrade to authenticated after login:
+export function LandingPage() {
+  useEffect(() => {
+    wsClient.connect({ anonymous: true });
+    return () => wsClient.disconnect({ permanent: true });
+  }, []);
+  return <Hero />;
+}
+```
+
+**`disconnect()` vs `disconnect({ permanent: true })`**
+
+- `disconnect()` — closes the socket, but the underlying socket.io Manager remains. Calling `connect()` again reuses it (faster reconnect).
+- `disconnect({ permanent: true })` — also removes every listener and nulls out the socket reference. The next `connect()` builds everything from scratch. Use this for logout flows where you want zero state from the previous session to leak forward.
+
+**Status transitions you'll see in the Redux slice:**
 
 ```
-[ws] connect() was called in a server context.
-WebSocket clients run in the browser only.
-Move the call into a "use client" component, or guard it with typeof window !== 'undefined'.
+idle ──connect()──▶ connecting ──handshake ok──▶ connected
+                                       │
+                                       │ transport closes (network)
+                                       ▼
+                                  reconnecting ──handshake ok──▶ connected
+                                       │
+                                       │ user calls disconnect()
+                                       │ or server force-disconnect reconnectable=false
+                                       ▼
+                                  disconnected
 ```
 
-In practice you won't hit this — the hooks are marked `'use client'` and only run in effects (which fire after hydration). The error catches misuse from non-React code paths (utility imports, etc.).
+### Listening to server events
 
----
+`useWsEvent(event, handler)` is the default tool. It:
+- Subscribes on mount.
+- Unsubscribes on unmount or when `event` changes.
+- Triggers a lazy `connect()` on first mount.
+- Uses a stable handler ref internally — inline arrows don't cause re-subscriptions on every render.
 
-## Adding custom events
+```tsx
+useWsEvent('presence:online', (payload) => {
+  // payload is typed as { userId: string; timestamp: number }
+  toast(`${payload.userId} just came online`);
+});
+```
 
-The backend's `ClientToServerEvents` / `ServerToClientEvents` interfaces are the contract. To extend on the frontend, use TypeScript declaration merging — keep the merge near the feature that introduces the event:
+#### Conditional subscriptions
+
+Pass the event name conditionally only if you really need to — the hook re-subscribes when `event` changes:
+
+```tsx
+const event = userId ? 'presence:online' : null;
+useWsEvent(event ?? 'presence:online', (p) => { /* still typed */ });
+```
+
+Most of the time you want the subscription unconditionally and a guard inside the handler:
+
+```tsx
+useWsEvent('presence:online', (payload) => {
+  if (payload.userId !== targetUserId) return;
+  /* ... */
+});
+```
+
+#### Multiple subscriptions in one component
+
+Each `useWsEvent` call is independent. The hook handles cleanup individually.
+
+```tsx
+useWsEvent('presence:online',  handleOnline);
+useWsEvent('presence:offline', handleOffline);
+useWsEvent('error',            handleError);
+```
+
+#### Subscribing to system events for diagnostics
+
+Useful in dev / debug consoles:
+
+```tsx
+useWsEvent('error',                  (e) => console.warn('[ws] error', e));
+useWsEvent('auth:error',             (e) => console.error('[ws] auth error', e));
+useWsEvent('auth:force:disconnect',  (p) => console.warn('[ws] forced disconnect', p));
+useWsEvent('pong',                   ({ timestamp }) => debugRtt(Date.now() - timestamp));
+```
+
+### Sending events to the server
+
+`useWsEmit()` returns a stable, fully-typed emit function. It's safe to put in a `useCallback` dependency array.
+
+```tsx
+const emit = useWsEmit();
+emit('presence:subscribe', { userId });    // returns true / false
+```
+
+Return value: `true` when the socket was open and the event was dispatched; `false` when the socket was disconnected (the event is dropped, not queued).
+
+#### Emitting in response to user actions
+
+```tsx
+function ChatInput({ roomId }: { roomId: string }) {
+  const emit = useWsEmit();
+  const [text, setText] = useState('');
+
+  const send = () => {
+    // Assuming you've declared 'message:send' via declaration merging:
+    const ok = emit('message:send', { roomId, content: text });
+    if (!ok) {
+      toast('Not connected — try again in a moment');
+      return;
+    }
+    setText('');
+  };
+
+  return /* ... */;
+}
+```
+
+#### Emitting on effect mount (without `useWsEvent`)
+
+If you only need to emit, not subscribe, drive it from `useWsStatus`:
+
+```tsx
+function PresenceSubscription({ userId }: { userId: string }) {
+  const { isConnected } = useWsStatus();
+  const emit = useWsEmit();
+
+  useEffect(() => {
+    if (!isConnected) return;
+    emit('presence:subscribe', { userId });
+    return () => { emit('presence:unsubscribe', { userId }); };
+  }, [isConnected, userId, emit]);
+
+  return null;
+}
+```
+
+**Note:** `useWsEmit` alone does NOT trigger a lazy connect (it can't — there's nothing to subscribe to yet). If you need a socket without subscribing to anything, call `wsClient.connect()` from a `useEffect`. In practice every app subscribes to at least one event somewhere.
+
+### Reading and reacting to connection state
+
+`useWsStatus()` returns each slice field as an independent selector — components only re-render when the field they read changes.
+
+```tsx
+const {
+  status,                  // 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'disconnected'
+  isConnected,             // boolean — convenience for status === 'connected'
+  isDisconnectedFatally,   // true when reconnectable === false (server denial)
+  socketId,                // current socket id, or null
+  lastError,               // last WsErrorPayload, or null
+  forceDisconnectReason,   // WsDisconnectReason | null
+  reconnectable,           // boolean | null — branch on this, not on `reason`
+} = useWsStatus();
+```
+
+#### A connection-status badge
+
+```tsx
+function ConnectionBadge() {
+  const { status } = useWsStatus();
+  const colour = {
+    idle: 'gray',
+    connecting: 'amber',
+    connected: 'green',
+    reconnecting: 'amber',
+    disconnected: 'red',
+  }[status];
+  return <Dot colour={colour} title={status} />;
+}
+```
+
+#### Reacting to fatal disconnects
+
+When the server force-disconnects with `reconnectable: false` (session revoked, rate limited, etc.), `isDisconnectedFatally` flips true. Use it to drive the "you've been signed out" UI:
+
+```tsx
+function SessionGuard() {
+  const { isDisconnectedFatally, forceDisconnectReason } = useWsStatus();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isDisconnectedFatally) return;
+    if (forceDisconnectReason === 'session_revoked') {
+      router.push('/login?reason=signed-out-elsewhere');
+    } else if (forceDisconnectReason === 'max_connections') {
+      toast('Too many devices connected. Close another tab to continue.');
+    }
+  }, [isDisconnectedFatally, forceDisconnectReason, router]);
+
+  return null;
+}
+```
+
+#### Reading raw selectors for advanced cases
+
+If `useWsStatus` is too coarse (you only care about one field, want shallow-equal memoisation, etc.), use the named selectors directly with `useAppSelector`:
+
+```tsx
+import { useAppSelector } from '@/store/hooks';
+import { selectWsLastError } from '@/lib/utils/ws';
+
+const error = useAppSelector(selectWsLastError);
+```
+
+### Presence (online/offline tracking)
+
+The backend tracks which users are online via Redis. To watch a specific user, subscribe at the WS level and let the slice / hooks fan the updates out:
+
+```tsx
+function UserPresenceDot({ userId }: { userId: string }) {
+  const { isConnected } = useWsStatus();
+  const emit = useWsEmit();
+  const [online, setOnline] = useState<boolean | null>(null);
+
+  // Subscribe / unsubscribe on the WS gateway
+  useEffect(() => {
+    if (!isConnected) return;
+    emit('presence:subscribe', { userId });
+    return () => { emit('presence:unsubscribe', { userId }); };
+  }, [isConnected, userId, emit]);
+
+  // Snapshot — the server sends this once after subscribe
+  useWsEvent('presence:status', ({ userId: uid, status }) => {
+    if (uid === userId) setOnline(status === 'online');
+  });
+
+  // Live updates
+  useWsEvent('presence:online',  ({ userId: uid }) => { if (uid === userId) setOnline(true); });
+  useWsEvent('presence:offline', ({ userId: uid }) => { if (uid === userId) setOnline(false); });
+
+  return <Dot colour={online ? 'green' : online === false ? 'gray' : 'transparent'} />;
+}
+```
+
+**Per-socket cap:** 50 presence subscriptions (backend-enforced). If you need to watch more users, design around it — e.g. subscribe to a room and let the server fan out, rather than subscribing to every user individually.
+
+### Handling server-initiated disconnects
+
+The backend can force a disconnect for several reasons. **Always branch on `reconnectable`, never on `reason`** — the reason is for logs/UX; the boolean is the contract.
+
+| `reason` | `reconnectable` | Client behaviour | UI guidance |
+|---|---|---|---|
+| `session_revoked` | `false` | Auto-reconnect is **disabled** | Route to login; clear in-memory user state |
+| `max_connections` | `false` | Auto-reconnect is **disabled** | Show "device limit reached"; suggest closing other tabs |
+| `rate_limited` | `false` | Auto-reconnect is **disabled** | Show "too many connection attempts"; back off ~60 s before letting the user retry |
+| `roles_changed` | `true` | Socket.IO reconnects transparently | No UI; permissions refresh on the new handshake |
+| `max_age` | `true` | Socket.IO reconnects transparently | No UI |
+| `server_shutdown` | `true` | Socket.IO reconnects transparently | No UI; new connection lands on a healthy node |
+
+You typically only need a single top-level component handling all of these:
+
+```tsx
+function WsForceDisconnectHandler() {
+  const { forceDisconnectReason, reconnectable } = useWsStatus();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!forceDisconnectReason) return;
+    if (reconnectable) return; // operational — Socket.IO handles it
+
+    switch (forceDisconnectReason) {
+      case 'session_revoked':
+        clearAuthState();
+        router.push('/login?reason=signed-out-elsewhere');
+        break;
+      case 'max_connections':
+        toast.error('Maximum device limit reached. Close another tab.');
+        break;
+      case 'rate_limited':
+        toast.error('Too many connection attempts. Try again in a minute.');
+        break;
+    }
+  }, [forceDisconnectReason, reconnectable, router]);
+
+  return null;
+}
+```
+
+Mount it once near the root of the authenticated app shell.
+
+### Public / anonymous flows
+
+Anonymous mode reaches only `@WsPublic()` handlers. The backend currently exposes `ping`, `presence:subscribe`, and `presence:unsubscribe` as public — enough to build a "live visitor count" or public-presence widget without forcing authentication.
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useWsEvent, wsClient } from '@/lib/utils/ws';
+
+export function LandingPagePresenceCount() {
+  const [online, setOnline] = useState(0);
+
+  useEffect(() => {
+    // Open a public socket on mount, close on unmount.
+    wsClient.connect({ anonymous: true });
+    return () => wsClient.disconnect({ permanent: true });
+  }, []);
+
+  useWsEvent('presence:online',  () => setOnline((n) => n + 1));
+  useWsEvent('presence:offline', () => setOnline((n) => Math.max(0, n - 1)));
+
+  return <span>{online} people online</span>;
+}
+```
+
+**Upgrading from anonymous to authenticated after login:** call `wsClient.disconnect({ permanent: true })` first, then `wsClient.connect()` (without `anonymous`). The handshake re-runs with credentials.
+
+### Multi-namespace apps
+
+The default `wsClient` connects to `/ws`. For separate gateways like `/chat` or `/notifications`, create dedicated clients with `createWsClient`:
+
+```ts
+// src/features/chat/client.ts
+import { createWsClient } from '@/lib/utils/ws';
+
+export const chatWsClient = createWsClient({ namespace: '/chat' });
+```
+
+Each client is an independent `WsClient` instance with its own socket, heartbeat, and lifecycle. They share the same `socket.io-client` Manager only if you pass the same URL — by default, separate URLs mean separate Managers.
+
+The default Redux bridge is wired to `wsClient` only. If you want connection state for a custom client in Redux too, wire your own bridge in a custom slice — the `attachWsBridge` function works against any `WsClient`. Alternatively, keep the custom client's state local to its feature.
+
+```ts
+// Custom slice for chat connection state
+import { attachWsBridge } from '@/lib/utils/ws';
+import { chatWsClient } from '@/features/chat/client';
+
+// Inside a provider effect:
+useEffect(() => attachWsBridge(chatWsClient, dispatch), [dispatch]);
+```
+
+### Adding custom feature events
+
+The backend's `ClientToServerEvents` / `ServerToClientEvents` are the contract. To extend on the frontend, use TypeScript declaration merging — keep the merge file near the feature that introduces the event:
 
 ```ts
 // src/features/chat/types/ws-events.ts
-import '@/lib/utils/ws'; // ensures the base interface is loaded
+import '@/lib/utils/ws'; // ensure base interface is loaded
 
 declare module '@/lib/utils/ws' {
   interface ClientToServerEvents {
@@ -316,18 +567,105 @@ declare module '@/lib/utils/ws' {
 }
 ```
 
-Then in feature code:
+Import that file once at app load (e.g. from a root `app/[locale]/layout.tsx` or a `features/<feature>/index.ts` barrel that's already imported). Then in any feature file:
 
 ```tsx
-useWsEvent('message:new', (msg) => {       // fully typed
+const emit = useWsEmit();
+emit('message:send', { roomId, content });   // fully typed
+
+useWsEvent('message:new', (msg) => {           // fully typed
   appendToTimeline(msg);
 });
-
-const emit = useWsEmit();
-emit('message:send', { roomId, content }); // fully typed
 ```
 
-**Coordinate with the backend** — events not declared in the backend's gateway are silently dropped on the server. Add the handler on the gateway side first.
+**Coordinate with the backend.** Events not declared on the backend's gateway are silently dropped on the server. Add the `@SubscribeMessage` handler there first; then add the frontend declarations.
+
+### Imperative use outside React
+
+The `wsClient` singleton is callable from anywhere in the browser bundle. Useful for non-React code paths — analytics, debug consoles, Redux thunks, etc.
+
+```ts
+import { wsClient } from '@/lib/utils/ws';
+
+// In a Redux thunk:
+export const sendChatMessage = (roomId: string, content: string) =>
+  (dispatch, getState) => {
+    if (!wsClient.isConnected()) {
+      dispatch(showError('Not connected'));
+      return;
+    }
+    wsClient.emit('message:send', { roomId, content });
+  };
+
+// In a debug-console helper exposed for QA:
+declare global { interface Window { __ws: typeof wsClient } }
+window.__ws = wsClient;
+```
+
+`wsClient` works correctly even before any React component renders — it's a lazy proxy. The first method call constructs the underlying instance.
+
+### Cleanup on logout
+
+A typical logout flow with WS state:
+
+```ts
+async function logout() {
+  // 1. Disconnect WS permanently — drop all listeners + socket reference.
+  wsClient.disconnect({ permanent: true });
+
+  // 2. Reset the WS slice to clear stale status / lastError / etc.
+  store.dispatch(wsReset());
+
+  // 3. Hit the HTTP logout endpoint — clears the access/refresh cookies.
+  await fetchClient.post('/auth/logout');
+
+  // 4. Clear any in-memory auth state (Redux auth slice, secure storage in bearer mode).
+  store.dispatch(authReset());
+
+  // 5. Route to login.
+  router.push('/login');
+}
+```
+
+**Why `permanent: true`?** A plain `disconnect()` keeps the Manager alive so a future `connect()` is faster. But on logout, you want zero state from the previous session — including any in-flight reconnection attempts. `permanent: true` guarantees a clean slate.
+
+### Testing components that use the WS layer
+
+The test environment already mocks `react-secure-storage` globally (`test/setup.ts`). For component tests, mock `wsClient` per-test so you can assert on subscribe/emit calls without opening a real socket:
+
+```tsx
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TestProviders } from '../../test/test-utils';
+
+const onEventMock = vi.fn();
+const emitMock = vi.fn().mockReturnValue(true);
+const getStatusMock = vi.fn().mockReturnValue('connected');
+
+vi.mock('@/lib/utils/ws/client', () => ({
+  wsClient: {
+    onEvent: (...args) => { onEventMock(...args); return () => {}; },
+    emit: emitMock,
+    getStatus: getStatusMock,
+    connect: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const { useWsEvent, useWsEmit } = await import('@/lib/utils/ws');
+
+describe('MyChatPanel', () => {
+  it('subscribes to message:new and emits message:send', () => {
+    const { result } = renderHook(() => /* ... */, { wrapper: TestProviders });
+    expect(onEventMock).toHaveBeenCalledWith('message:new', expect.any(Function));
+
+    act(() => { result.current.send('hi'); });
+    expect(emitMock).toHaveBeenCalledWith('message:send', { content: 'hi' });
+  });
+});
+```
+
+For end-to-end-style tests of the client itself (not feature code), see `src/lib/utils/ws/client/ws-client.test.ts` and the `FakeSocket` test utility in `src/lib/utils/ws/__test-utils__/fake-socket.ts`.
 
 ---
 
@@ -364,7 +702,7 @@ export const chatWsClient = createWsClient({ namespace: '/chat' });
 | `useWsEvent(event, handler)` | Subscribe to a server event. Lazy connect on first call. |
 | `useWsEmit()` | Stable, typed emit function. |
 
-### Selectors (advanced)
+### Selectors
 
 Exported from `@/lib/utils/ws`. Use them with `useAppSelector` when `useWsStatus` is too coarse:
 
@@ -402,13 +740,21 @@ The event name in `useWsEvent` doesn't match the backend's gateway. Check:
 
 Backend's `WS_MAX_CONNECTION_AGE_MS` (default 24 h). The client auto-reconnects on this reason — if you're seeing rapid cycles, check that `reconnectable: true` is being honoured (your custom force-disconnect handler may be tearing things down).
 
-### Sessions revoked when I refresh the page
+### "Sessions revoked when I refresh the page"
 
 Cookie-mode relies on the browser carrying the access cookie. If your dev setup has frontend on a different origin from the backend (e.g. `localhost:3000` vs `localhost:8080`), check the backend's `COOKIE_SAMESITE` and `COOKIE_DOMAIN`.
+
+### "Connection drops every ~2 minutes"
+
+Application-level heartbeat isn't reaching the server. The client sends `ping` every 25 s — if a corporate proxy or service-worker is blocking outgoing pings, the backend's Redis socket TTL (default 120 s) expires and the next push event finds no socket. Check that `transports: ['websocket']` is actually negotiated (look for `Sec-WebSocket-Protocol` in DevTools) and that no service worker is intercepting `/ws`.
 
 ### Tests fail with "Cannot set properties of null (setting 'textBaseline')"
 
 `react-secure-storage` constructs its encryption service at import time and calls `<canvas>.getContext`, which jsdom doesn't implement. Already handled — `test/setup.ts` stubs `react-secure-storage` globally. If you hit this in a fresh test file, make sure your test config uses `test/setup.ts` as `setupFiles`.
+
+### "Two sockets open at once during dev"
+
+React 18+ in Strict Mode double-invokes effects in dev. The lazy-connect path is idempotent (a second `connect()` while connecting is a no-op), but if you wrote your own `useEffect` calling `wsClient.connect()`, make sure the cleanup function calls `wsClient.disconnect()` — Strict Mode's teardown-then-rerun is the safety check for exactly this kind of bug.
 
 ---
 

--- a/src/lib/utils/ws/README.md
+++ b/src/lib/utils/ws/README.md
@@ -1,0 +1,420 @@
+# WebSocket Client
+
+**TL;DR** — Typed Socket.IO client wrapping `socket.io-client` against the NestJS-starter backend. Cookie-mode auth by default, public/anonymous mode opt-in. Heartbeat, reconnection, and `auth:force:disconnect` handling are built in. Connection state flows through Redux; subscriptions through three small hooks. **Browser-only** — opening a socket from a Server Component throws.
+
+```
+src/lib/utils/ws/
+├─ types/           backend-mirrored event maps + payload shapes
+├─ shared/          runtime guard, auth-carrier, URL composer (internal)
+├─ client/          WsClient class + default `wsClient` singleton (lazy)
+├─ redux/           bridge + selectors (internal: only StoreProvider attaches)
+├─ hooks/           useWsStatus, useWsEvent, useWsEmit
+├─ constants.ts     namespace, heartbeat interval, reconnection bounds
+└─ index.ts         public barrel
+```
+
+Feature code imports from `@/lib/utils/ws` only. `shared/`, `redux/bridge`, and `client/internals` are private — reaching into them breaks at the next refactor.
+
+---
+
+## Table of Contents
+
+- [Quick start](#quick-start)
+- [Configuration](#configuration)
+- [Architecture](#architecture)
+- [Authentication](#authentication)
+- [Hooks](#hooks)
+- [Lifecycle & reconnection](#lifecycle--reconnection)
+- [Force-disconnect (server-initiated)](#force-disconnect-server-initiated)
+- [Heartbeat](#heartbeat)
+- [Token renewal](#token-renewal)
+- [Presence](#presence)
+- [Public / anonymous connections](#public--anonymous-connections)
+- [SSR boundary](#ssr-boundary)
+- [Adding custom events](#adding-custom-events)
+- [API reference](#api-reference)
+- [Troubleshooting](#troubleshooting)
+- [Related docs](#related-docs)
+
+---
+
+## Quick start
+
+```tsx
+'use client';
+
+import { useWsEvent, useWsEmit, useWsStatus } from '@/lib/utils/ws';
+
+export function PresenceWidget({ userId }: { userId: string }) {
+  const { isConnected } = useWsStatus();
+  const emit = useWsEmit();
+
+  useEffect(() => {
+    if (isConnected) emit('presence:subscribe', { userId });
+    return () => { emit('presence:unsubscribe', { userId }); };
+  }, [isConnected, userId, emit]);
+
+  useWsEvent('presence:online', ({ userId: uid }) => {
+    if (uid === userId) console.log(`${userId} is online`);
+  });
+
+  return <span>{isConnected ? '🟢' : '⚪'}</span>;
+}
+```
+
+No explicit `connect()` — `useWsEvent` triggers a lazy connect on first subscribe. The transport opens once and stays alive for the app lifetime.
+
+---
+
+## Configuration
+
+### Environment
+
+Reuses `NEXT_PUBLIC_API_URL` from the HTTP layer — **bare origin** (no `/api/v{n}` suffix). The WS client strips any accidental version path and appends the namespace:
+
+```
+NEXT_PUBLIC_API_URL=https://api.example.com   →  wss://api.example.com/ws
+NEXT_PUBLIC_API_URL=                          →  /ws   (same-origin)
+```
+
+No new env var. If you change the WS namespace server-side, override via `createWsClient({ namespace: '/chat' })` or the `WS_NAMESPACE` constant.
+
+### Constants
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `WS_NAMESPACE` | `/ws` | Backend namespace mounted by `WsGateway` |
+| `WS_HEARTBEAT_INTERVAL_MS` | `25_000` | Application-level `ping` cadence. Must be < backend `WS_SOCKET_TTL_SECONDS` (default 120 s) |
+| `WS_TOKEN_RENEWAL_LEAD_MS` | `60_000` | Lead time before access-token expiry (bearer mode only) |
+| `WS_RECONNECTION_DELAY_MIN_MS` | `1_000` | Socket.IO reconnection base delay |
+| `WS_RECONNECTION_DELAY_MAX_MS` | `10_000` | Socket.IO reconnection cap (exponential backoff) |
+| `SAVE_AUTH_TOKENS` | `false` | Cookie-mode (default) vs bearer-mode (re-uses the HTTP layer's flag) |
+
+All defaults match the backend's documented defaults (`nestjs-starter/docs/socket.md` §3, §15) — tune only if you've changed the matching backend env vars.
+
+---
+
+## Architecture
+
+```
+                  ┌───────────────────────────────────┐
+                  │  React component                  │
+                  │   useWsStatus / useWsEvent /      │
+                  │   useWsEmit                       │
+                  └────────┬──────────────────┬───────┘
+              reads state  │                  │  emits / subscribes
+                           ▼                  ▼
+                  ┌──────────────┐   ┌──────────────────┐
+                  │  ws Redux    │   │  wsClient        │
+                  │  slice       │◀──┤  (singleton)     │
+                  │              │   │                  │
+                  │  status      │   │  socket.io-client│
+                  │  socketId    │   │  + heartbeat     │
+                  │  lastError   │   │  + force-disc    │
+                  └──────────────┘   └────────┬─────────┘
+                          ▲                   │
+                          │                   │ WSS / transports:['websocket']
+                          │  bridge           ▼
+                          │             ┌─────────────────┐
+                          └─────────────┤  Backend /ws    │
+                            dispatches   │  (NestJS)      │
+                                         └─────────────────┘
+```
+
+- **`wsClient`** owns one underlying socket. Lifecycle (connect, reconnect, heartbeat, force-disconnect, token renewal) lives here.
+- **The bridge** subscribes to `wsClient`'s lifecycle emitter and dispatches into the ws slice. It is the **only** code path that touches the slice — never dispatch into it from feature code.
+- **Hooks** read state from the slice (`useWsStatus`) or talk to the socket (`useWsEvent`, `useWsEmit`).
+- **Connection is lazy.** `wsClient.connect()` is called automatically by the first `useWsEvent` subscriber. No subscribers, no socket — the transport doesn't open at module load.
+
+---
+
+## Authentication
+
+### Cookie-mode (default)
+
+`SAVE_AUTH_TOKENS = false`. The browser cookie jar carries the `access` HttpOnly cookie on the Socket.IO handshake automatically — the backend's three-source extractor reads it from `handshake.headers.cookie`. **No auth payload is sent.** Tokens never touch JavaScript.
+
+### Bearer-mode
+
+`SAVE_AUTH_TOKENS = true`. The client reads the access token from `secureStorageTokenStore` and sends it as `handshake.auth.token`. The backend extracts it first (priority 1 over cookie). If no token is stored, `connect()` rejects with `WS_AUTH_REQUIRED` before opening the socket.
+
+Both modes work transparently against the same backend — the only difference is where the token rides.
+
+---
+
+## Hooks
+
+### `useWsStatus()`
+
+Read-only window onto the connection. Each field is a separate selector so components only re-render when their own datum changes.
+
+```ts
+const {
+  status,                  // 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'disconnected'
+  isConnected,             // boolean
+  isDisconnectedFatally,   // true when server sent reconnectable=false
+  socketId,                // current socket id, or null
+  lastError,               // last WsErrorPayload, or null
+  forceDisconnectReason,   // WsDisconnectReason | null
+  reconnectable,           // boolean | null
+} = useWsStatus();
+```
+
+### `useWsEvent(event, handler)`
+
+Subscribe to a server-emitted event. The handler is captured by ref, so passing an inline arrow doesn't cause re-subscriptions on every render. Only `event` is a real dependency.
+
+```tsx
+useWsEvent('presence:online', ({ userId, timestamp }) => {
+  // typed automatically from ServerToClientEvents
+});
+```
+
+**Triggers a lazy connect** on first subscriber. Subsequent subscriptions reuse the open socket.
+
+### `useWsEmit()`
+
+Returns a stable, fully-typed emit function. Returns `false` if the socket isn't connected yet.
+
+```tsx
+const emit = useWsEmit();
+emit('presence:subscribe', { userId });   // type-checked against ClientToServerEvents
+```
+
+---
+
+## Lifecycle & reconnection
+
+| Status | Meaning |
+|---|---|
+| `idle` | No connection attempt yet. |
+| `connecting` | Initial connect in flight. |
+| `connected` | Socket open, handshake accepted, ready to send/receive. |
+| `reconnecting` | Transport closed unexpectedly; socket.io-client is retrying (exponential backoff capped at 10 s). |
+| `disconnected` | Explicitly disconnected, or the server force-disconnected with `reconnectable: false`. |
+
+Socket.IO drives reconnection automatically for network failures (`transport close`, `ping timeout`). The client respects the server's `reconnectable` flag — when the backend sends `auth:force:disconnect` with `reconnectable: false`, auto-reconnect is **disabled** until you call `connect()` explicitly. This prevents login-loop storms after session revocation.
+
+---
+
+## Force-disconnect (server-initiated)
+
+The backend emits `auth:force:disconnect` with `{ reason, reconnectable }`. **Branch on `reconnectable`, not `reason`.**
+
+| `reason` | `reconnectable` | UI guidance |
+|---|---|---|
+| `session_revoked` | `false` | Show "signed out elsewhere"; route to login |
+| `max_connections` | `false` | Show "device limit reached"; suggest closing other tabs |
+| `rate_limited` | `false` | Show "too many connection attempts"; back off ~60 s |
+| `roles_changed` | `true` | Reconnect happens transparently — new handshake pulls fresh permissions |
+| `max_age` | `true` | Reconnect happens transparently |
+| `server_shutdown` | `true` | Reconnect happens transparently — lands on a healthy node |
+
+The Redux slice exposes both `forceDisconnectReason` and `reconnectable`; the helper `selectWsIsDisconnectedFatally` checks `reconnectable === false`.
+
+```tsx
+const { isDisconnectedFatally, forceDisconnectReason } = useWsStatus();
+
+useEffect(() => {
+  if (isDisconnectedFatally && forceDisconnectReason === 'session_revoked') {
+    router.push('/login');
+  }
+}, [isDisconnectedFatally, forceDisconnectReason]);
+```
+
+---
+
+## Heartbeat
+
+The client sends `ping` every 25 s to refresh the backend's Redis socket-metadata TTL (default 120 s server-side) and trigger a roles-version check. This is **separate** from socket.io's engine.io ping — both run. Heartbeat starts on `connect` and stops on `disconnect`; you don't manage it.
+
+If you change `WS_HEARTBEAT_INTERVAL_MS`, also change the backend's `WS_SOCKET_TTL_SECONDS` to stay > interval × 4.
+
+---
+
+## Token renewal
+
+**Cookie-mode (default): not implemented in v1.** When the access token nears expiry, the socket disconnects and reconnects — the browser cookie jar supplies a fresh access cookie on the new handshake (refreshed by the HTTP layer on the next API call). One sub-second blip near token expiry.
+
+**Bearer-mode:** Future work. The backend supports in-place `auth:token:renew` (rate-limited to 5/min) but the v1 client doesn't schedule it. Subscribe to `auth:token:renewed` if you implement renewal yourself, and call `wsClient.emit('auth:token:renew', { refreshToken })` ahead of expiry.
+
+---
+
+## Presence
+
+Backend tracks online/offline state in Redis. To watch a specific user:
+
+```tsx
+const emit = useWsEmit();
+
+useEffect(() => {
+  emit('presence:subscribe', { userId });
+  return () => { emit('presence:unsubscribe', { userId }); };
+}, [userId, emit]);
+
+useWsEvent('presence:status', ({ userId: uid, status, lastSeen }) => {
+  /* initial snapshot for `uid` */
+});
+
+useWsEvent('presence:online',  ({ userId: uid }) => { /* uid came online */ });
+useWsEvent('presence:offline', ({ userId: uid }) => { /* uid went offline */ });
+```
+
+Cap: 50 subscriptions per socket (backend-enforced).
+
+---
+
+## Public / anonymous connections
+
+The backend supports unauthenticated sockets — they only reach `@WsPublic()` handlers (currently `ping`, `presence:subscribe`, `presence:unsubscribe`). To opt in:
+
+```ts
+await wsClient.connect({ anonymous: true });
+```
+
+The handshake is sent without an auth payload and without a cookie. The backend admits the connection up to a global cap (`WS_MAX_ANONYMOUS_SOCKETS`, default 10,000).
+
+Default is `anonymous: false` — connect refuses in bearer-mode without a token; cookie-mode optimistically connects and the server rejects if the cookie is missing.
+
+---
+
+## SSR boundary
+
+Opening a WebSocket from a Server Component is **always** a bug — there's no client to listen on the other end. The WS layer throws `WsSsrError` instead of silently no-op'ing:
+
+```
+[ws] connect() was called in a server context.
+WebSocket clients run in the browser only.
+Move the call into a "use client" component, or guard it with typeof window !== 'undefined'.
+```
+
+In practice you won't hit this — the hooks are marked `'use client'` and only run in effects (which fire after hydration). The error catches misuse from non-React code paths (utility imports, etc.).
+
+---
+
+## Adding custom events
+
+The backend's `ClientToServerEvents` / `ServerToClientEvents` interfaces are the contract. To extend on the frontend, use TypeScript declaration merging — keep the merge near the feature that introduces the event:
+
+```ts
+// src/features/chat/types/ws-events.ts
+import '@/lib/utils/ws'; // ensures the base interface is loaded
+
+declare module '@/lib/utils/ws' {
+  interface ClientToServerEvents {
+    'message:send': (payload: { roomId: string; content: string }) => void;
+  }
+  interface ServerToClientEvents {
+    'message:new': (payload: {
+      id: string;
+      roomId: string;
+      authorId: string;
+      content: string;
+      createdAt: string;
+    }) => void;
+  }
+}
+```
+
+Then in feature code:
+
+```tsx
+useWsEvent('message:new', (msg) => {       // fully typed
+  appendToTimeline(msg);
+});
+
+const emit = useWsEmit();
+emit('message:send', { roomId, content }); // fully typed
+```
+
+**Coordinate with the backend** — events not declared in the backend's gateway are silently dropped on the server. Add the handler on the gateway side first.
+
+---
+
+## API reference
+
+### `wsClient` (default singleton)
+
+| Method | Returns | Notes |
+|---|---|---|
+| `connect(opts?)` | `Promise<void>` | Opens the socket. `{ anonymous: true }` to skip auth. Idempotent. |
+| `disconnect(opts?)` | `void` | Closes the socket. `{ permanent: true }` removes all listeners. |
+| `getStatus()` | `WsStatus` | Current connection status (matches the slice). |
+| `getSocketId()` | `string \| null` | Current socket id or null when disconnected. |
+| `isConnected()` | `boolean` | Convenience for `status === 'connected'`. |
+| `on(event, h)` | `() => void` | Subscribe to a lifecycle event (used by the bridge — rarely needed in feature code). |
+| `onEvent(event, h)` | `() => void` | Subscribe to a server→client event (used by hooks). |
+| `emit(event, ...)` | `boolean` | Emit a client→server event. Returns false when disconnected. |
+
+### `createWsClient(opts?)`
+
+Build an additional client for a different namespace, custom URL, or custom `socket.io-client` options. Used for multi-namespace apps (`/chat`, `/notifications`). Each instance is independent.
+
+```ts
+import { createWsClient } from '@/lib/utils/ws';
+
+export const chatWsClient = createWsClient({ namespace: '/chat' });
+```
+
+### Hooks
+
+| Hook | Purpose |
+|---|---|
+| `useWsStatus()` | Read connection state from Redux. |
+| `useWsEvent(event, handler)` | Subscribe to a server event. Lazy connect on first call. |
+| `useWsEmit()` | Stable, typed emit function. |
+
+### Selectors (advanced)
+
+Exported from `@/lib/utils/ws`. Use them with `useAppSelector` when `useWsStatus` is too coarse:
+
+`selectWsStatus`, `selectWsSocketId`, `selectWsLastError`, `selectWsForceDisconnectReason`, `selectWsReconnectable`, `selectWsConnectedAt`, `selectWsAnonymous`, `selectWsIsConnected`, `selectWsIsDisconnectedFatally`.
+
+### Types
+
+All exported from `@/lib/utils/ws`:
+
+- **Events:** `ClientToServerEvents`, `ServerToClientEvents`, `ClientEventName`, `ServerEventName`
+- **Payloads:** `WsErrorPayload`, `WsForceDisconnectPayload`, `WsPongPayload`, `WsPresencePayload`, `WsPresenceStatusPayload`, `WsTokenRenewedPayload`
+- **Disconnect:** `WS_DISCONNECT_REASON` (const), `WsDisconnectReason` (union), `isReconnectableReason()`
+- **Transport:** `WsStatus`, `WsClientOptions`, `WsConnectOptions`
+
+---
+
+## Troubleshooting
+
+### `WsSsrError: connect() was called in a server context`
+
+You imported `wsClient` or one of its hooks into a Server Component. The hooks ship with `'use client'` so this almost always means an imperative call (`wsClient.connect()`) is happening at module top-level. Wrap it in `useEffect` or move it into a client component.
+
+### "Status stays `idle` forever"
+
+No subscriber has triggered the lazy connect. Either render a component that calls `useWsEvent` / `useWsEmit`, or call `wsClient.connect()` explicitly from an effect.
+
+### "Connected but events don't arrive"
+
+The event name in `useWsEvent` doesn't match the backend's gateway. Check:
+1. The backend handler is registered with `@SubscribeMessage('foo:bar')`.
+2. The frontend declares the same name in `ServerToClientEvents`.
+3. CORS allows your origin — Socket.IO uses the same CORS gate as HTTP.
+
+### "Server keeps disconnecting me with `max_age`"
+
+Backend's `WS_MAX_CONNECTION_AGE_MS` (default 24 h). The client auto-reconnects on this reason — if you're seeing rapid cycles, check that `reconnectable: true` is being honoured (your custom force-disconnect handler may be tearing things down).
+
+### Sessions revoked when I refresh the page
+
+Cookie-mode relies on the browser carrying the access cookie. If your dev setup has frontend on a different origin from the backend (e.g. `localhost:3000` vs `localhost:8080`), check the backend's `COOKIE_SAMESITE` and `COOKIE_DOMAIN`.
+
+### Tests fail with "Cannot set properties of null (setting 'textBaseline')"
+
+`react-secure-storage` constructs its encryption service at import time and calls `<canvas>.getContext`, which jsdom doesn't implement. Already handled — `test/setup.ts` stubs `react-secure-storage` globally. If you hit this in a fresh test file, make sure your test config uses `test/setup.ts` as `setupFiles`.
+
+---
+
+## Related docs
+
+- Backend WS contract → `nestjs-starter/docs/socket.md`
+- Event interfaces (source of truth) → `nestjs-starter/src/infrastructure/websocket/types/ws-events.interface.ts`
+- Disconnect reasons + reconnectable policy → `nestjs-starter/src/infrastructure/websocket/websocket.constants.ts`
+- HTTP layer (sibling) → `src/lib/utils/http/README.md`

--- a/src/lib/utils/ws/__test-utils__/fake-socket.ts
+++ b/src/lib/utils/ws/__test-utils__/fake-socket.ts
@@ -1,0 +1,83 @@
+import { vi } from 'vitest';
+
+/**
+ * Minimal socket.io-client surface mock. Drives `WsClient` through its
+ * lifecycle without opening a real WebSocket. Lifecycle calls are exposed
+ * as `simulate*` methods so tests can be explicit about what they're
+ * triggering.
+ */
+export class FakeSocket {
+  id: string | null = 'fake-socket-id';
+  connected = false;
+
+  private readonly listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  private readonly managerListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  readonly io = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      let set = this.managerListeners.get(event);
+      if (!set) {
+        set = new Set();
+        this.managerListeners.set(event, set);
+      }
+      set.add(handler);
+      return this.io;
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      this.managerListeners.get(event)?.delete(handler);
+      return this.io;
+    }),
+    opts: { reconnection: true } as { reconnection: boolean },
+  };
+
+  on = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    let set = this.listeners.get(event);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(event, set);
+    }
+    set.add(handler);
+    return this;
+  });
+
+  off = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    this.listeners.get(event)?.delete(handler);
+    return this;
+  });
+
+  emit = vi.fn((..._args: unknown[]) => this);
+  removeAllListeners = vi.fn();
+  disconnect = vi.fn(() => {
+    this.connected = false;
+    this.fire('disconnect', 'io client disconnect');
+    return this;
+  });
+
+  // ── Test-side drivers ─────────────────────────────────────────────────────
+
+  simulateConnect(): void {
+    this.connected = true;
+    this.fire('connect');
+  }
+
+  simulateDisconnect(reason = 'transport close'): void {
+    this.connected = false;
+    this.fire('disconnect', reason);
+  }
+
+  simulateServerEvent(event: string, ...args: unknown[]): void {
+    this.fire(event, ...args);
+  }
+
+  simulateManagerEvent(event: string, ...args: unknown[]): void {
+    const set = this.managerListeners.get(event);
+    if (!set) return;
+    for (const h of [...set]) h(...args);
+  }
+
+  private fire(event: string, ...args: unknown[]): void {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    for (const h of [...set]) h(...args);
+  }
+}

--- a/src/lib/utils/ws/client/client.ts
+++ b/src/lib/utils/ws/client/client.ts
@@ -1,0 +1,40 @@
+import { WsClient } from './ws-client';
+
+/**
+ * Default app-wide WebSocket client. Lazily constructed on first access so
+ * importing this module from a server-bundled file (e.g. an isomorphic
+ * shared util) doesn't instantiate anything until a client component
+ * actually uses it. Mirrors the `fetchClient` / `axiosClient` pattern.
+ *
+ * For multi-namespace apps, use {@link createWsClient} to spin up
+ * additional instances.
+ */
+let _wsClient: WsClient | null = null;
+
+function getWsClient(): WsClient {
+  if (!_wsClient) {
+    _wsClient = new WsClient();
+  }
+  return _wsClient;
+}
+
+// Use a Proxy so the export name `wsClient` works as a singleton accessor
+// without the user having to remember to call a function. Method calls
+// transparently route to the lazily-built instance.
+export const wsClient = new Proxy({} as WsClient, {
+  get(_target, prop, receiver) {
+    const client = getWsClient();
+    const value = Reflect.get(client, prop, receiver);
+    return typeof value === 'function' ? value.bind(client) : value;
+  },
+});
+
+/**
+ * Test hook — reset the singleton between specs. Not part of the public
+ * API; only the test setup should use it.
+ *
+ * @internal
+ */
+export function __resetWsClientForTests(): void {
+  _wsClient = null;
+}

--- a/src/lib/utils/ws/client/index.ts
+++ b/src/lib/utils/ws/client/index.ts
@@ -1,0 +1,10 @@
+export { __resetWsClientForTests, wsClient } from './client';
+export { LifecycleEmitter } from './lifecycle-emitter';
+export type {
+  WsClientOptions,
+  WsConnectOptions,
+  WsLifecycleEventName,
+  WsLifecycleEvents,
+  WsStatus,
+} from './types';
+export { createWsClient, WsClient } from './ws-client';

--- a/src/lib/utils/ws/client/lifecycle-emitter.ts
+++ b/src/lib/utils/ws/client/lifecycle-emitter.ts
@@ -1,0 +1,43 @@
+import type { WsLifecycleEventName, WsLifecycleEvents } from './types';
+
+/**
+ * Minimal typed event-emitter for lifecycle events. We don't expose the
+ * underlying `Socket` instance to feature code — the bridge and hooks
+ * subscribe to this emitter for status/error/disconnect transitions.
+ *
+ * Keeping the emitter internal means:
+ * - Tests can assert lifecycle without a real socket.
+ * - The Redux bridge is one subscription point, not many.
+ * - Future internals changes (e.g. swapping socket.io-client for a custom
+ *   transport) don't ripple through feature code.
+ */
+export class LifecycleEmitter {
+  private readonly listeners = new Map<WsLifecycleEventName, Set<(...args: unknown[]) => void>>();
+
+  on<E extends WsLifecycleEventName>(event: E, handler: WsLifecycleEvents[E]): () => void {
+    let set = this.listeners.get(event);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(event, set);
+    }
+    set.add(handler as (...args: unknown[]) => void);
+    return () => this.off(event, handler);
+  }
+
+  off<E extends WsLifecycleEventName>(event: E, handler: WsLifecycleEvents[E]): void {
+    this.listeners.get(event)?.delete(handler as (...args: unknown[]) => void);
+  }
+
+  emit<E extends WsLifecycleEventName>(event: E, ...args: Parameters<WsLifecycleEvents[E]>): void {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    // Copy before iteration so handlers can off() themselves safely.
+    for (const handler of [...set]) {
+      (handler as (...a: unknown[]) => void)(...args);
+    }
+  }
+
+  clear(): void {
+    this.listeners.clear();
+  }
+}

--- a/src/lib/utils/ws/client/types.ts
+++ b/src/lib/utils/ws/client/types.ts
@@ -1,0 +1,42 @@
+import type { ManagerOptions, SocketOptions } from 'socket.io-client';
+
+import type { WsErrorPayload, WsForceDisconnectPayload } from '../types';
+
+/** Connection status surface mirrored into the Redux slice. */
+export type WsStatus = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'disconnected';
+
+export interface WsClientOptions {
+  /** WebSocket URL. Defaults to `getWsUrl(namespace)`. */
+  url?: string;
+  /** Backend namespace path. Defaults to `WS_NAMESPACE` (`/ws`). */
+  namespace?: string;
+  /**
+   * Override the socket.io-client options merge. Use sparingly — the
+   * defaults match the backend's documented requirements (`transports:
+   * ['websocket']`, `withCredentials: true`, capped exponential backoff).
+   */
+  socketOptions?: Partial<ManagerOptions & SocketOptions>;
+}
+
+export interface WsConnectOptions {
+  /**
+   * Connect without authentication. The backend allows it, but only
+   * `@WsPublic()` handlers are reachable. Use for landing-page presence
+   * widgets, public dashboards, etc. Default `false` — `connect()` rejects
+   * with `WS_AUTH_REQUIRED` if there is no token / cookie context.
+   */
+  anonymous?: boolean;
+}
+
+/** Lifecycle events the bridge and hooks subscribe to. */
+export interface WsLifecycleEvents {
+  statusChange: (status: WsStatus, socketId: string | null) => void;
+  error: (error: WsErrorPayload) => void;
+  forceDisconnect: (payload: WsForceDisconnectPayload) => void;
+  /** Fires once whenever a fresh socket id is assigned (on each connect). */
+  socketIdChange: (socketId: string | null) => void;
+  /** Fires on every successful application-level pong (after a `ping`). */
+  pong: (timestamp: number) => void;
+}
+
+export type WsLifecycleEventName = keyof WsLifecycleEvents;

--- a/src/lib/utils/ws/client/ws-client.test.ts
+++ b/src/lib/utils/ws/client/ws-client.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FakeSocket } from '../__test-utils__/fake-socket';
+import { WS_DISCONNECT_REASON } from '../types';
+import { WsClient } from './ws-client';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const SAVE_AUTH_TOKENS = { value: false };
+vi.mock('@/lib/config', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/config')>('@/lib/config');
+  return {
+    ...actual,
+    get SAVE_AUTH_TOKENS() {
+      return SAVE_AUTH_TOKENS.value;
+    },
+  };
+});
+
+// Mock socket.io-client's `io` factory to return our FakeSocket.
+let fakeSocket: FakeSocket;
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => fakeSocket),
+}));
+
+describe('WsClient', () => {
+  beforeEach(() => {
+    fakeSocket = new FakeSocket();
+    SAVE_AUTH_TOKENS.value = false;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('connect()', () => {
+    it('transitions idle → connecting → connected', async () => {
+      const client = new WsClient();
+      const statuses: string[] = [];
+      client.on('statusChange', (s) => statuses.push(s));
+
+      await client.connect();
+      expect(statuses).toEqual(['connecting']);
+
+      fakeSocket.simulateConnect();
+      expect(statuses).toEqual(['connecting', 'connected']);
+      expect(client.isConnected()).toBe(true);
+      expect(client.getSocketId()).toBe('fake-socket-id');
+    });
+
+    it('is idempotent — second call while connecting is a no-op', async () => {
+      const client = new WsClient();
+      await client.connect();
+      const ioMock = (await import('socket.io-client')).io;
+      const firstCount = vi.mocked(ioMock).mock.calls.length;
+
+      await client.connect();
+      expect(vi.mocked(ioMock).mock.calls.length).toBe(firstCount);
+    });
+
+    it('refuses without auth context in bearer mode and emits AUTH_REQUIRED', async () => {
+      SAVE_AUTH_TOKENS.value = true;
+      // No token stored — buildHandshakeAuth returns undefined.
+      const client = new WsClient();
+      const errors: unknown[] = [];
+      client.on('error', (e) => errors.push(e));
+
+      await expect(client.connect()).rejects.toThrow(/AUTH_REQUIRED|authentication context/);
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as { code: string }).code).toBe('WS_AUTH_REQUIRED');
+    });
+
+    it('allows anonymous connect even without auth', async () => {
+      SAVE_AUTH_TOKENS.value = true;
+      const client = new WsClient();
+      await expect(client.connect({ anonymous: true })).resolves.toBeUndefined();
+      fakeSocket.simulateConnect();
+      expect(client.isConnected()).toBe(true);
+    });
+  });
+
+  describe('heartbeat', () => {
+    it('emits ping every WS_HEARTBEAT_INTERVAL_MS while connected', async () => {
+      const client = new WsClient();
+      await client.connect();
+      fakeSocket.simulateConnect();
+
+      vi.advanceTimersByTime(25_000);
+      expect(fakeSocket.emit).toHaveBeenCalledWith('ping');
+
+      vi.advanceTimersByTime(25_000);
+      expect(fakeSocket.emit).toHaveBeenCalledTimes(2);
+    });
+
+    it('stops on disconnect', async () => {
+      const client = new WsClient();
+      await client.connect();
+      fakeSocket.simulateConnect();
+
+      fakeSocket.simulateDisconnect();
+      vi.advanceTimersByTime(60_000);
+      expect(fakeSocket.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reconnection lifecycle', () => {
+    it('transport-close disconnect → status becomes reconnecting', async () => {
+      const client = new WsClient();
+      const statuses: string[] = [];
+      client.on('statusChange', (s) => statuses.push(s));
+
+      await client.connect();
+      fakeSocket.simulateConnect();
+      fakeSocket.simulateDisconnect('transport close');
+
+      expect(statuses).toContain('reconnecting');
+    });
+
+    it('explicit client disconnect → status becomes disconnected (no reconnect)', async () => {
+      const client = new WsClient();
+      const statuses: string[] = [];
+      client.on('statusChange', (s) => statuses.push(s));
+
+      await client.connect();
+      fakeSocket.simulateConnect();
+      client.disconnect();
+
+      expect(statuses[statuses.length - 1]).toBe('disconnected');
+    });
+  });
+
+  describe('auth:force:disconnect', () => {
+    it('non-reconnectable reason latches fatalDisconnect and disables reconnection', async () => {
+      const client = new WsClient();
+      const events: unknown[] = [];
+      client.on('forceDisconnect', (p) => events.push(p));
+
+      await client.connect();
+      fakeSocket.simulateConnect();
+
+      fakeSocket.simulateServerEvent('auth:force:disconnect', {
+        reason: WS_DISCONNECT_REASON.SESSION_REVOKED,
+        reconnectable: false,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(fakeSocket.io.opts.reconnection).toBe(false);
+
+      // A subsequent transport close should NOT flip to reconnecting.
+      const statuses: string[] = [];
+      client.on('statusChange', (s) => statuses.push(s));
+      fakeSocket.simulateDisconnect('transport close');
+      expect(statuses).toEqual(['disconnected']);
+    });
+
+    it('reconnectable reason leaves auto-reconnect untouched', async () => {
+      const client = new WsClient();
+      await client.connect();
+      fakeSocket.simulateConnect();
+
+      fakeSocket.simulateServerEvent('auth:force:disconnect', {
+        reason: WS_DISCONNECT_REASON.ROLES_CHANGED,
+        reconnectable: true,
+      });
+
+      expect(fakeSocket.io.opts.reconnection).toBe(true);
+    });
+
+    it('back-compat: missing `reconnectable` falls back to isReconnectableReason()', async () => {
+      const client = new WsClient();
+      const events: { reconnectable: boolean }[] = [];
+      client.on('forceDisconnect', (p) => events.push(p));
+
+      await client.connect();
+      fakeSocket.simulateConnect();
+
+      // Simulate an older backend that didn't stamp `reconnectable`.
+      fakeSocket.simulateServerEvent('auth:force:disconnect', {
+        reason: WS_DISCONNECT_REASON.SERVER_SHUTDOWN,
+      });
+
+      expect(events[0].reconnectable).toBe(true);
+    });
+  });
+
+  describe('error pass-through', () => {
+    it('forwards server `error` events to the lifecycle emitter', async () => {
+      const client = new WsClient();
+      const errors: unknown[] = [];
+      client.on('error', (e) => errors.push(e));
+
+      await client.connect();
+      fakeSocket.simulateConnect();
+      fakeSocket.simulateServerEvent('error', { code: 'BAD', message: 'boom' });
+
+      expect(errors).toEqual([{ code: 'BAD', message: 'boom' }]);
+    });
+
+    it('translates manager-level transport errors to WS_TRANSPORT_ERROR', async () => {
+      const client = new WsClient();
+      const errors: { code: string }[] = [];
+      client.on('error', (e) => errors.push(e));
+
+      await client.connect();
+      fakeSocket.simulateManagerEvent('error', new Error('econnreset'));
+
+      expect(errors[0].code).toBe('WS_TRANSPORT_ERROR');
+    });
+  });
+
+  describe('emit', () => {
+    it('returns false when socket is not connected', async () => {
+      const client = new WsClient();
+      // emit's typed signature requires a known event; ping has an optional ack arg.
+      expect(client.emit('ping')).toBe(false);
+
+      await client.connect();
+      expect(client.emit('ping')).toBe(false); // still connecting
+      fakeSocket.simulateConnect();
+      expect(client.emit('ping')).toBe(true);
+    });
+  });
+
+  describe('SSR guard', () => {
+    it('throws WsSsrError when called server-side', async () => {
+      const originalWindow = globalThis.window;
+      // @ts-expect-error — deleting for SSR simulation
+      delete globalThis.window;
+      try {
+        const client = new WsClient();
+        await expect(client.connect()).rejects.toThrow(/server context/);
+      } finally {
+        globalThis.window = originalWindow;
+      }
+    });
+  });
+});

--- a/src/lib/utils/ws/client/ws-client.ts
+++ b/src/lib/utils/ws/client/ws-client.ts
@@ -1,0 +1,255 @@
+import { io, type ManagerOptions, type Socket, type SocketOptions } from 'socket.io-client';
+
+import { SAVE_AUTH_TOKENS } from '@/lib/config';
+import { logger } from '@/lib/logger';
+
+import {
+  WS_HEARTBEAT_INTERVAL_MS,
+  WS_LOCAL_ERROR_CODES,
+  WS_RECONNECTION_DELAY_MAX_MS,
+  WS_RECONNECTION_DELAY_MIN_MS,
+} from '../constants';
+import { buildHandshakeAuth, ensureBrowser, getWsUrl } from '../shared';
+import type {
+  ClientToServerEvents,
+  ServerToClientEvents,
+  WsErrorPayload,
+  WsForceDisconnectPayload,
+} from '../types';
+import { isReconnectableReason } from '../types';
+import { LifecycleEmitter } from './lifecycle-emitter';
+import type { WsClientOptions, WsConnectOptions, WsStatus } from './types';
+
+type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+/**
+ * Stateful WebSocket client wrapping `socket.io-client`. One instance owns
+ * one underlying `Socket`. Designed as a singleton per namespace (use
+ * {@link createWsClient} for additional namespaces).
+ *
+ * **Lifecycle is event-driven, not promise-driven.** Subscribe to status
+ * changes via the lifecycle emitter (the Redux bridge does this for you).
+ * Connection happens lazily on first `connect()` or on first subscriber via
+ * `useWsEvent`.
+ *
+ * Force-disconnect with `reconnectable: false` (session revoked, etc.)
+ * marks the client `disconnected` and refuses to auto-reconnect. Call
+ * `connect()` again explicitly after the user re-authenticates.
+ */
+export class WsClient {
+  private readonly options: WsClientOptions;
+  private readonly emitter = new LifecycleEmitter();
+
+  private socket: TypedSocket | null = null;
+  private status: WsStatus = 'idle';
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  /** Set when force-disconnect tells us not to reconnect. Cleared on next explicit connect(). */
+  private fatalDisconnect = false;
+
+  constructor(options: WsClientOptions = {}) {
+    this.options = options;
+  }
+
+  // ── Status ──────────────────────────────────────────────────────────────────
+
+  getStatus(): WsStatus {
+    return this.status;
+  }
+
+  getSocketId(): string | null {
+    return this.socket?.id ?? null;
+  }
+
+  isConnected(): boolean {
+    return this.status === 'connected';
+  }
+
+  on = this.emitter.on.bind(this.emitter);
+  off = this.emitter.off.bind(this.emitter);
+
+  // ── Connect / disconnect ────────────────────────────────────────────────────
+
+  /**
+   * Open the connection. Idempotent — calling on an already-connected (or
+   * connecting) socket is a no-op. Resets the `fatalDisconnect` latch so
+   * the caller can explicitly reconnect after a denial.
+   */
+  async connect(options: WsConnectOptions = {}): Promise<void> {
+    ensureBrowser('connect');
+    if (this.socket && this.status !== 'idle' && this.status !== 'disconnected') {
+      return;
+    }
+
+    this.fatalDisconnect = false;
+    this.setStatus('connecting');
+
+    const anonymous = options.anonymous ?? false;
+    const auth = await buildHandshakeAuth({ anonymous });
+
+    // Cookie mode (SAVE_AUTH_TOKENS=false) is always optimistic — the browser
+    // jar carries the access cookie automatically and the server rejects if
+    // it's missing. Bearer mode with no stored token (auth === undefined and
+    // not anonymous) is the one combination that should fail fast.
+    if (!anonymous && SAVE_AUTH_TOKENS && !auth) {
+      this.setStatus('disconnected');
+      this.emitter.emit('error', {
+        code: WS_LOCAL_ERROR_CODES.AUTH_REQUIRED,
+        message: 'connect() requires either an auth token or anonymous: true.',
+      });
+      throw new Error('[ws] connect() requires authentication context or anonymous: true.');
+    }
+
+    const url = this.options.url ?? getWsUrl(this.options.namespace);
+    const socketOpts: Partial<ManagerOptions & SocketOptions> = {
+      transports: ['websocket'],
+      withCredentials: true,
+      reconnection: true,
+      reconnectionDelay: WS_RECONNECTION_DELAY_MIN_MS,
+      reconnectionDelayMax: WS_RECONNECTION_DELAY_MAX_MS,
+      reconnectionAttempts: Number.POSITIVE_INFINITY,
+      auth,
+      ...this.options.socketOptions,
+    };
+
+    this.socket = io(url, socketOpts) as TypedSocket;
+    this.wireSocket(this.socket);
+  }
+
+  /**
+   * Close the connection. Use for logout flows where the caller wants to
+   * stop reconnection too — pass `{ permanent: true }` to also clear the
+   * underlying Manager so subsequent `connect()` builds a fresh one.
+   */
+  disconnect(options: { permanent?: boolean } = {}): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    if (!this.socket) {
+      this.setStatus('disconnected');
+      return;
+    }
+
+    this.socket.disconnect();
+    if (options.permanent) {
+      this.socket.removeAllListeners();
+      this.socket = null;
+    }
+    this.setStatus('disconnected');
+  }
+
+  // ── Event subscription (typed pass-through to socket.io-client) ────────────
+
+  /** Subscribe to a server-emitted event. Returns an unsubscribe function. */
+  onEvent<E extends keyof ServerToClientEvents>(
+    event: E,
+    handler: ServerToClientEvents[E],
+  ): () => void {
+    if (!this.socket) {
+      // Buffer would add complexity; instead require connect() first.
+      // The hooks call connect() lazily before subscribing, so feature
+      // code never hits this path.
+      throw new Error('[ws] onEvent() called before connect(). Call connect() first.');
+    }
+    this.socket.on(event, handler as never);
+    return () => {
+      this.socket?.off(event, handler as never);
+    };
+  }
+
+  /** Emit a client→server event. Returns true if dispatched (socket open). */
+  emit<E extends keyof ClientToServerEvents>(
+    event: E,
+    ...args: Parameters<ClientToServerEvents[E]>
+  ): boolean {
+    if (!this.socket?.connected) return false;
+    // socket.io-client's `emit` signature is hostile to generics; the cast
+    // is safe because `args` is statically typed as the expected tuple.
+    (this.socket.emit as (event: string, ...args: unknown[]) => void)(event, ...args);
+    return true;
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────────────
+
+  private wireSocket(socket: TypedSocket): void {
+    socket.on('connect', () => {
+      this.setStatus('connected');
+      this.emitter.emit('socketIdChange', socket.id ?? null);
+      this.startHeartbeat();
+    });
+
+    socket.on('disconnect', (reason) => {
+      this.stopHeartbeat();
+      // socket.io-client auto-reconnects for `transport close`, `ping timeout`,
+      // and network errors. For explicit server-side disconnects (`io server
+      // disconnect`) it does not — those are handled by the force-disconnect
+      // event below. We mirror that by setting reconnecting vs disconnected.
+      if (this.fatalDisconnect) {
+        this.setStatus('disconnected');
+        return;
+      }
+      const willReconnect = reason !== 'io client disconnect' && reason !== 'io server disconnect';
+      this.setStatus(willReconnect ? 'reconnecting' : 'disconnected');
+      this.emitter.emit('socketIdChange', null);
+    });
+
+    socket.io.on('reconnect_attempt', () => {
+      if (!this.fatalDisconnect) this.setStatus('reconnecting');
+    });
+
+    socket.io.on('error', (err) => {
+      logger.warn({ err: err.message }, 'WS transport error');
+      this.emitter.emit('error', {
+        code: WS_LOCAL_ERROR_CODES.TRANSPORT_ERROR,
+        message: err.message || 'WebSocket transport error',
+      });
+    });
+
+    socket.on('error', (payload: WsErrorPayload) => {
+      this.emitter.emit('error', payload);
+    });
+
+    socket.on('auth:error', (payload: WsErrorPayload) => {
+      this.emitter.emit('error', payload);
+    });
+
+    socket.on('auth:force:disconnect', (payload: WsForceDisconnectPayload) => {
+      // Trust the server's `reconnectable` flag; the helper is only a
+      // defensive cross-check for clients running against an older backend.
+      const reconnectable = payload.reconnectable ?? isReconnectableReason(payload.reason);
+      if (!reconnectable) {
+        this.fatalDisconnect = true;
+        if (this.socket) this.socket.io.opts.reconnection = false;
+      }
+      this.emitter.emit('forceDisconnect', { ...payload, reconnectable });
+    });
+
+    socket.on('pong', (payload) => {
+      this.emitter.emit('pong', payload.timestamp);
+    });
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      if (this.socket?.connected) this.socket.emit('ping');
+    }, WS_HEARTBEAT_INTERVAL_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private setStatus(next: WsStatus): void {
+    if (this.status === next) return;
+    this.status = next;
+    this.emitter.emit('statusChange', next, this.socket?.id ?? null);
+  }
+}
+
+export function createWsClient(options: WsClientOptions = {}): WsClient {
+  return new WsClient(options);
+}

--- a/src/lib/utils/ws/constants.ts
+++ b/src/lib/utils/ws/constants.ts
@@ -1,0 +1,50 @@
+/**
+ * WebSocket transport constants.
+ *
+ * Mirrors the backend's documented defaults
+ * (`nestjs-starter/docs/socket.md` §3, §15). Tune locally only if you've
+ * changed the matching backend env vars — drift causes Redis TTLs to
+ * expire mid-connection.
+ */
+
+/** Backend namespace mounted by `WsGateway`. */
+export const WS_NAMESPACE = '/ws';
+
+/**
+ * Application-level heartbeat interval. **Not** the engine.io ping.
+ *
+ * The client sends `ping` every 25 s so the server refreshes the Redis
+ * socket-metadata TTL (default 120 s server-side) and re-checks the
+ * roles-version. Keep this strictly less than the server's
+ * `WS_SOCKET_TTL_SECONDS` (default 120 s) — otherwise the slot expires
+ * between pings and the socket is silently disconnected.
+ */
+export const WS_HEARTBEAT_INTERVAL_MS = 25_000;
+
+/**
+ * Schedule `auth:token:renew` this many ms before the access token expires.
+ * The backend rate-limits renewals to 5 / min, so this margin must comfortably
+ * exceed the typical request jitter (network blip + a one-shot retry).
+ */
+export const WS_TOKEN_RENEWAL_LEAD_MS = 60_000;
+
+/**
+ * Reconnection backoff bounds. Socket.IO doubles the delay on each attempt up
+ * to the max. The backend recommends 1 s → 10 s for typical apps.
+ */
+export const WS_RECONNECTION_DELAY_MIN_MS = 1_000;
+export const WS_RECONNECTION_DELAY_MAX_MS = 10_000;
+
+/**
+ * Connection error codes surfaced by the client when the failure is local
+ * (not a payload from the server). These never collide with server error
+ * codes because the server emits with structured payloads, not strings.
+ */
+export const WS_LOCAL_ERROR_CODES = {
+  /** Connection attempted from a non-browser runtime. */
+  SSR_BLOCKED: 'WS_SSR_BLOCKED',
+  /** Connect called without auth context when `anonymous: false` (default). */
+  AUTH_REQUIRED: 'WS_AUTH_REQUIRED',
+  /** Transport closed by underlying socket.io-client (network, timeout). */
+  TRANSPORT_ERROR: 'WS_TRANSPORT_ERROR',
+} as const;

--- a/src/lib/utils/ws/hooks/index.ts
+++ b/src/lib/utils/ws/hooks/index.ts
@@ -1,0 +1,3 @@
+export { useWsEmit } from './use-ws-emit';
+export { useWsEvent } from './use-ws-event';
+export { useWsStatus } from './use-ws-status';

--- a/src/lib/utils/ws/hooks/use-ws-emit.test.tsx
+++ b/src/lib/utils/ws/hooks/use-ws-emit.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TestProviders } from '../../../../../test/test-utils';
+
+const emitMock = vi.fn();
+vi.mock('../client', () => ({
+  wsClient: { emit: emitMock },
+}));
+
+const { useWsEmit } = await import('./use-ws-emit');
+
+describe('useWsEmit', () => {
+  beforeEach(() => {
+    emitMock.mockReset();
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns a stable function across renders', () => {
+    const { result, rerender } = renderHook(() => useWsEmit(), {
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it('forwards event + args to wsClient.emit', () => {
+    emitMock.mockReturnValue(true);
+    const { result } = renderHook(() => useWsEmit(), {
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+
+    const ok = result.current('presence:subscribe', { userId: 'u-1' });
+    expect(emitMock).toHaveBeenCalledWith('presence:subscribe', { userId: 'u-1' });
+    expect(ok).toBe(true);
+  });
+
+  it('returns false when the underlying client refuses (disconnected)', () => {
+    emitMock.mockReturnValue(false);
+    const { result } = renderHook(() => useWsEmit(), {
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+
+    expect(result.current('ping')).toBe(false);
+  });
+});

--- a/src/lib/utils/ws/hooks/use-ws-emit.ts
+++ b/src/lib/utils/ws/hooks/use-ws-emit.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { wsClient } from '../client';
+import type { ClientToServerEvents } from '../types';
+
+/**
+ * Typed `emit` accessor. Returns a stable function whose signature is
+ * inferred from {@link ClientToServerEvents} — pick an event name and the
+ * compiler enforces the payload shape.
+ *
+ * Returns `false` if the socket isn't connected yet. Callers that need
+ * delivery confirmation should subscribe to the server's ack-bearing
+ * events (`auth:token:renew` has an ack) or use a server→client follow-up
+ * event.
+ *
+ * @example
+ * ```tsx
+ * const emit = useWsEmit();
+ * emit('presence:subscribe', { userId: '...' });
+ * ```
+ */
+export function useWsEmit() {
+  return useCallback(
+    <E extends keyof ClientToServerEvents>(
+      event: E,
+      ...args: Parameters<ClientToServerEvents[E]>
+    ): boolean => wsClient.emit(event, ...args),
+    [],
+  );
+}

--- a/src/lib/utils/ws/hooks/use-ws-event.test.tsx
+++ b/src/lib/utils/ws/hooks/use-ws-event.test.tsx
@@ -1,0 +1,108 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TestProviders } from '../../../../../test/test-utils';
+
+// Mock the wsClient module BEFORE importing the hook. The hook's lazy
+// connect calls .getStatus() and may call .connect(); .onEvent() is the
+// subscription path. Each is a vi.fn so we can assert call shape.
+const onEventMock = vi.fn();
+const connectMock = vi.fn().mockResolvedValue(undefined);
+const getStatusMock = vi.fn();
+const unsubscribeMock = vi.fn();
+
+vi.mock('../client', () => ({
+  wsClient: {
+    onEvent: (...args: unknown[]) => {
+      onEventMock(...args);
+      return unsubscribeMock;
+    },
+    connect: connectMock,
+    getStatus: getStatusMock,
+  },
+}));
+
+const { useWsEvent } = await import('./use-ws-event');
+
+describe('useWsEvent', () => {
+  beforeEach(() => {
+    onEventMock.mockClear();
+    connectMock.mockClear();
+    getStatusMock.mockReset();
+    unsubscribeMock.mockClear();
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('subscribes to the event on mount and unsubscribes on unmount', () => {
+    getStatusMock.mockReturnValue('connected');
+    const handler = vi.fn();
+
+    const { unmount } = renderHook(() => useWsEvent('presence:online', handler), {
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+
+    expect(onEventMock).toHaveBeenCalledTimes(1);
+    expect(onEventMock.mock.calls[0][0]).toBe('presence:online');
+
+    unmount();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('triggers lazy connect() when status is idle', () => {
+    getStatusMock.mockReturnValue('idle');
+    renderHook(() => useWsEvent('pong', () => {}), {
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+    expect(connectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call connect() when already connected', () => {
+    getStatusMock.mockReturnValue('connected');
+    renderHook(() => useWsEvent('pong', () => {}), {
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+    expect(connectMock).not.toHaveBeenCalled();
+  });
+
+  it('uses a stable handler ref — does not re-subscribe on handler-only re-render', () => {
+    getStatusMock.mockReturnValue('connected');
+    const { rerender } = renderHook(({ h }: { h: () => void }) => useWsEvent('pong', h as never), {
+      initialProps: { h: vi.fn() },
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+
+    rerender({ h: vi.fn() });
+    rerender({ h: vi.fn() });
+
+    // Only the first mount should have subscribed.
+    expect(onEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards payloads to the latest handler ref', () => {
+    getStatusMock.mockReturnValue('connected');
+    let captured: ((p: unknown) => void) | undefined;
+    onEventMock.mockImplementation((_event, dispatch: (p: unknown) => void) => {
+      captured = dispatch;
+      return unsubscribeMock;
+    });
+
+    const handlerA = vi.fn();
+    const handlerB = vi.fn();
+    const { rerender } = renderHook(
+      ({ h }: { h: (p: unknown) => void }) => useWsEvent('pong', h as never),
+      {
+        initialProps: { h: handlerA },
+        wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+      },
+    );
+
+    captured?.({ timestamp: 1 });
+    expect(handlerA).toHaveBeenCalledWith({ timestamp: 1 });
+
+    rerender({ h: handlerB });
+    captured?.({ timestamp: 2 });
+    expect(handlerB).toHaveBeenCalledWith({ timestamp: 2 });
+    expect(handlerA).toHaveBeenCalledTimes(1); // still only the first call
+  });
+});

--- a/src/lib/utils/ws/hooks/use-ws-event.test.tsx
+++ b/src/lib/utils/ws/hooks/use-ws-event.test.tsx
@@ -51,7 +51,8 @@ describe('useWsEvent', () => {
 
   it('triggers lazy connect() when status is idle', () => {
     getStatusMock.mockReturnValue('idle');
-    renderHook(() => useWsEvent('pong', () => {}), {
+    const noop = vi.fn();
+    renderHook(() => useWsEvent('pong', noop), {
       wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
     });
     expect(connectMock).toHaveBeenCalledTimes(1);
@@ -59,7 +60,8 @@ describe('useWsEvent', () => {
 
   it('does NOT call connect() when already connected', () => {
     getStatusMock.mockReturnValue('connected');
-    renderHook(() => useWsEvent('pong', () => {}), {
+    const noop = vi.fn();
+    renderHook(() => useWsEvent('pong', noop), {
       wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
     });
     expect(connectMock).not.toHaveBeenCalled();

--- a/src/lib/utils/ws/hooks/use-ws-event.ts
+++ b/src/lib/utils/ws/hooks/use-ws-event.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { wsClient } from '../client';
+import type { ServerToClientEvents } from '../types';
+
+/**
+ * Subscribe to a server-emitted WS event. Automatically attaches on mount,
+ * detaches on unmount or when `event` changes. Triggers a lazy connect on
+ * first subscriber so feature code never has to call `wsClient.connect()`
+ * explicitly — but you can still call it yourself if you need to control
+ * timing (e.g. wait for auth context).
+ *
+ * The handler is captured by ref so users can pass an inline arrow without
+ * causing re-subscriptions on every render. Only `event` is a real
+ * dependency.
+ *
+ * @example
+ * ```tsx
+ * useWsEvent('presence:online', ({ userId }) => {
+ *   showToast(`${userId} is online`);
+ * });
+ * ```
+ */
+export function useWsEvent<E extends keyof ServerToClientEvents>(
+  event: E,
+  handler: ServerToClientEvents[E],
+): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    // Lazy connect — does nothing if already connected/connecting.
+    if (wsClient.getStatus() === 'idle') {
+      void wsClient.connect().catch(() => {
+        // Connect errors flow through the lifecycle emitter → Redux slice;
+        // we don't need to surface them again at the hook boundary.
+      });
+    }
+
+    const dispatch = ((...args: Parameters<ServerToClientEvents[E]>) => {
+      // Typed cast — `handlerRef.current` is `ServerToClientEvents[E]`,
+      // which is a function whose Parameters match `args` by construction.
+      (handlerRef.current as (...a: Parameters<ServerToClientEvents[E]>) => void)(...args);
+    }) as ServerToClientEvents[E];
+
+    const unsubscribe = wsClient.onEvent(event, dispatch);
+    return unsubscribe;
+  }, [event]);
+}

--- a/src/lib/utils/ws/hooks/use-ws-status.test.tsx
+++ b/src/lib/utils/ws/hooks/use-ws-status.test.tsx
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { TestProviders } from '../../../../../test/test-utils';
+import { WS_DISCONNECT_REASON } from '../types';
+import { useWsStatus } from './use-ws-status';
+
+describe('useWsStatus', () => {
+  it('reflects the initial idle state', () => {
+    const { result } = renderHook(() => useWsStatus(), {
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+    expect(result.current.status).toBe('idle');
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.isDisconnectedFatally).toBe(false);
+  });
+
+  it('reflects a connected store state', () => {
+    const { result } = renderHook(() => useWsStatus(), {
+      wrapper: ({ children }) => (
+        <TestProviders
+          preloadedState={{
+            ws: {
+              status: 'connected',
+              socketId: 'sock-1',
+              lastError: null,
+              forceDisconnectReason: null,
+              reconnectable: null,
+              connectedAt: 123,
+              anonymous: false,
+            },
+          }}
+        >
+          {children}
+        </TestProviders>
+      ),
+    });
+    expect(result.current.status).toBe('connected');
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.socketId).toBe('sock-1');
+  });
+
+  it('flags a fatal disconnect when reconnectable=false', () => {
+    const { result } = renderHook(() => useWsStatus(), {
+      wrapper: ({ children }) => (
+        <TestProviders
+          preloadedState={{
+            ws: {
+              status: 'disconnected',
+              socketId: null,
+              lastError: null,
+              forceDisconnectReason: WS_DISCONNECT_REASON.SESSION_REVOKED,
+              reconnectable: false,
+              connectedAt: null,
+              anonymous: false,
+            },
+          }}
+        >
+          {children}
+        </TestProviders>
+      ),
+    });
+    expect(result.current.isDisconnectedFatally).toBe(true);
+    expect(result.current.forceDisconnectReason).toBe(WS_DISCONNECT_REASON.SESSION_REVOKED);
+  });
+});

--- a/src/lib/utils/ws/hooks/use-ws-status.ts
+++ b/src/lib/utils/ws/hooks/use-ws-status.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useAppSelector } from '@/store/hooks';
+
+import {
+  selectWsForceDisconnectReason,
+  selectWsIsConnected,
+  selectWsIsDisconnectedFatally,
+  selectWsLastError,
+  selectWsReconnectable,
+  selectWsSocketId,
+  selectWsStatus,
+} from '../redux';
+
+/**
+ * Read-only window onto the WebSocket connection state.
+ *
+ * Returns the slice fields most consumers actually need, fanned out into
+ * separate selectors so each component only re-renders when its own datum
+ * changes. If you need bulk access, prefer composing the individual
+ * selectors over reading the slice wholesale.
+ */
+export function useWsStatus() {
+  return {
+    status: useAppSelector(selectWsStatus),
+    isConnected: useAppSelector(selectWsIsConnected),
+    isDisconnectedFatally: useAppSelector(selectWsIsDisconnectedFatally),
+    socketId: useAppSelector(selectWsSocketId),
+    lastError: useAppSelector(selectWsLastError),
+    forceDisconnectReason: useAppSelector(selectWsForceDisconnectReason),
+    reconnectable: useAppSelector(selectWsReconnectable),
+  };
+}

--- a/src/lib/utils/ws/index.ts
+++ b/src/lib/utils/ws/index.ts
@@ -1,0 +1,51 @@
+// Public surface for the WebSocket layer. Feature code imports from here.
+//
+// The shared/ and client/internals/ paths are NOT exported — feature code
+// should never touch them. If you need something not surfaced here, file a
+// PR rather than reaching into the internals.
+
+export {
+  __resetWsClientForTests,
+  createWsClient,
+  WsClient,
+  type WsClientOptions,
+  type WsConnectOptions,
+  type WsStatus,
+  wsClient,
+} from './client';
+export {
+  WS_HEARTBEAT_INTERVAL_MS,
+  WS_LOCAL_ERROR_CODES,
+  WS_NAMESPACE,
+  WS_RECONNECTION_DELAY_MAX_MS,
+  WS_RECONNECTION_DELAY_MIN_MS,
+  WS_TOKEN_RENEWAL_LEAD_MS,
+} from './constants';
+export { useWsEmit, useWsEvent, useWsStatus } from './hooks';
+export {
+  attachWsBridge,
+  selectWsAnonymous,
+  selectWsConnectedAt,
+  selectWsForceDisconnectReason,
+  selectWsIsConnected,
+  selectWsIsDisconnectedFatally,
+  selectWsLastError,
+  selectWsReconnectable,
+  selectWsSocketId,
+  selectWsStatus,
+} from './redux';
+export {
+  type ClientEventName,
+  type ClientToServerEvents,
+  isReconnectableReason,
+  type ServerEventName,
+  type ServerToClientEvents,
+  WS_DISCONNECT_REASON,
+  type WsDisconnectReason,
+  type WsErrorPayload,
+  type WsForceDisconnectPayload,
+  type WsPongPayload,
+  type WsPresencePayload,
+  type WsPresenceStatusPayload,
+  type WsTokenRenewedPayload,
+} from './types';

--- a/src/lib/utils/ws/redux/bridge.test.ts
+++ b/src/lib/utils/ws/redux/bridge.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { makeStore } from '@/store';
+
+import { LifecycleEmitter, type WsClient } from '../client';
+import { WS_DISCONNECT_REASON } from '../types';
+import { attachWsBridge } from './bridge';
+
+/**
+ * The bridge is the **only** code path that dispatches into the ws slice.
+ * Each lifecycle emitter event must map to exactly one Redux action.
+ */
+describe('attachWsBridge', () => {
+  function setup() {
+    const emitter = new LifecycleEmitter();
+    const fakeClient = { on: emitter.on.bind(emitter) } as unknown as WsClient;
+    const store = makeStore();
+    const teardown = attachWsBridge(fakeClient, store.dispatch);
+    return { emitter, store, teardown };
+  }
+
+  it('statusChange → ws.status + ws.socketId', () => {
+    const { emitter, store } = setup();
+    emitter.emit('statusChange', 'connected', 'sock-1');
+    const ws = store.getState().ws;
+    expect(ws.status).toBe('connected');
+    expect(ws.socketId).toBe('sock-1');
+  });
+
+  it('socketIdChange → ws.socketId only', () => {
+    const { emitter, store } = setup();
+    emitter.emit('socketIdChange', 'sock-xyz');
+    expect(store.getState().ws.socketId).toBe('sock-xyz');
+  });
+
+  it('error → ws.lastError', () => {
+    const { emitter, store } = setup();
+    emitter.emit('error', { code: 'BAD', message: 'boom' });
+    expect(store.getState().ws.lastError).toEqual({ code: 'BAD', message: 'boom' });
+  });
+
+  it('forceDisconnect → ws.forceDisconnectReason + ws.reconnectable', () => {
+    const { emitter, store } = setup();
+    emitter.emit('forceDisconnect', {
+      reason: WS_DISCONNECT_REASON.SESSION_REVOKED,
+      reconnectable: false,
+    });
+    const ws = store.getState().ws;
+    expect(ws.forceDisconnectReason).toBe(WS_DISCONNECT_REASON.SESSION_REVOKED);
+    expect(ws.reconnectable).toBe(false);
+  });
+
+  it('teardown detaches every listener', () => {
+    const emitter = new LifecycleEmitter();
+    const fakeClient = { on: emitter.on.bind(emitter) } as unknown as WsClient;
+    const store = makeStore();
+    const teardown = attachWsBridge(fakeClient, store.dispatch);
+
+    // Before teardown: lifecycle events DO reach the slice.
+    emitter.emit('error', { code: 'BEFORE', message: 'before' });
+    expect(store.getState().ws.lastError?.code).toBe('BEFORE');
+
+    teardown();
+
+    // After teardown: subsequent emits are inert.
+    emitter.emit('error', { code: 'AFTER', message: 'after' });
+    expect(store.getState().ws.lastError?.code).toBe('BEFORE');
+  });
+});

--- a/src/lib/utils/ws/redux/bridge.ts
+++ b/src/lib/utils/ws/redux/bridge.ts
@@ -1,0 +1,43 @@
+import type { AppDispatch } from '@/store';
+import {
+  wsErrored,
+  wsForceDisconnected,
+  wsSocketIdChanged,
+  wsStatusChanged,
+} from '@/store/slices/ws.slice';
+
+import type { WsClient } from '../client';
+
+/**
+ * Subscribe a Redux store to a `WsClient`'s lifecycle. Idempotent — calling
+ * twice returns the same teardown closure. The bridge is the **only** code
+ * path that ever dispatches WS slice actions; feature code reads state via
+ * selectors and never dispatches into this slice directly.
+ *
+ * Mount once per app, typically inside `StoreProvider` after the store is
+ * built. Returns a teardown function that unsubscribes every handler.
+ */
+export function attachWsBridge(client: WsClient, dispatch: AppDispatch): () => void {
+  const offStatus = client.on('statusChange', (status, socketId) => {
+    dispatch(wsStatusChanged({ status, socketId }));
+  });
+
+  const offSocketId = client.on('socketIdChange', (socketId) => {
+    dispatch(wsSocketIdChanged(socketId));
+  });
+
+  const offError = client.on('error', (payload) => {
+    dispatch(wsErrored(payload));
+  });
+
+  const offForce = client.on('forceDisconnect', ({ reason, reconnectable }) => {
+    dispatch(wsForceDisconnected({ reason, reconnectable }));
+  });
+
+  return () => {
+    offStatus();
+    offSocketId();
+    offError();
+    offForce();
+  };
+}

--- a/src/lib/utils/ws/redux/index.ts
+++ b/src/lib/utils/ws/redux/index.ts
@@ -1,0 +1,12 @@
+export { attachWsBridge } from './bridge';
+export {
+  selectWsAnonymous,
+  selectWsConnectedAt,
+  selectWsForceDisconnectReason,
+  selectWsIsConnected,
+  selectWsIsDisconnectedFatally,
+  selectWsLastError,
+  selectWsReconnectable,
+  selectWsSocketId,
+  selectWsStatus,
+} from './selectors';

--- a/src/lib/utils/ws/redux/selectors.ts
+++ b/src/lib/utils/ws/redux/selectors.ts
@@ -1,0 +1,25 @@
+import type { AppState } from '@/store';
+
+const selectWs = (state: AppState) => state.ws;
+
+export const selectWsStatus = (state: AppState) => selectWs(state).status;
+export const selectWsSocketId = (state: AppState) => selectWs(state).socketId;
+export const selectWsLastError = (state: AppState) => selectWs(state).lastError;
+export const selectWsForceDisconnectReason = (state: AppState) =>
+  selectWs(state).forceDisconnectReason;
+export const selectWsReconnectable = (state: AppState) => selectWs(state).reconnectable;
+export const selectWsConnectedAt = (state: AppState) => selectWs(state).connectedAt;
+export const selectWsAnonymous = (state: AppState) => selectWs(state).anonymous;
+
+/** True when the socket is fully connected. */
+export const selectWsIsConnected = (state: AppState) => selectWs(state).status === 'connected';
+
+/**
+ * True when the server told us not to reconnect (session revoked, max
+ * connections, rate limited). UI should treat this as "signed out" and
+ * stop trying to re-establish on its own.
+ */
+export const selectWsIsDisconnectedFatally = (state: AppState) => {
+  const ws = selectWs(state);
+  return ws.status === 'disconnected' && ws.reconnectable === false;
+};

--- a/src/lib/utils/ws/shared/auth-carrier.ts
+++ b/src/lib/utils/ws/shared/auth-carrier.ts
@@ -1,0 +1,45 @@
+import { SAVE_AUTH_TOKENS } from '@/lib/config';
+
+// Import from the leaf module, NOT the http barrel: the barrel transitively
+// pulls in `shared/cookie-injection` and `shared/server-cookies`, which
+// Turbopack flags as a `next/headers` import inside the client bundle.
+// The leaf only depends on `SecureStorageService`.
+import { secureStorageTokenStore } from '../../http/token-store';
+
+/**
+ * Build the Socket.IO `auth` payload for the handshake.
+ *
+ * Mode selection follows the same `SAVE_AUTH_TOKENS` lever as the HTTP layer:
+ *
+ * - **Cookie-mode** (`SAVE_AUTH_TOKENS = false`, default) — return `undefined`.
+ *   The browser cookie jar attaches the `access` HttpOnly cookie on the
+ *   handshake automatically (Socket.IO's transport is a regular WS upgrade
+ *   from an HTTP request, so cookies flow when `withCredentials` is set).
+ *
+ * - **Bearer-mode** (`SAVE_AUTH_TOKENS = true`) — return
+ *   `{ token: <accessToken> }`. The backend's three-source extractor
+ *   accepts `handshake.auth.token` with highest priority.
+ *
+ * - **Anonymous** (caller passed `anonymous: true`) — return `undefined`,
+ *   skipping both branches. The server falls into the anonymous-connection
+ *   path (only `@WsPublic()` handlers are reachable).
+ *
+ * Returning `undefined` is **the right shape** for socket.io-client — it
+ * leaves the `auth` field unset on the handshake rather than sending an
+ * empty object.
+ */
+export async function buildHandshakeAuth(options: {
+  anonymous: boolean;
+}): Promise<Record<string, string> | undefined> {
+  if (options.anonymous) return undefined;
+
+  if (!SAVE_AUTH_TOKENS) {
+    // Cookie path — the browser attaches `access` automatically. The server
+    // reads it from `handshake.headers.cookie`.
+    return undefined;
+  }
+
+  const token = await secureStorageTokenStore.getAccessToken();
+  if (!token) return undefined;
+  return { token };
+}

--- a/src/lib/utils/ws/shared/index.ts
+++ b/src/lib/utils/ws/shared/index.ts
@@ -1,0 +1,3 @@
+export { buildHandshakeAuth } from './auth-carrier';
+export { ensureBrowser, isBrowser, isServer, WsSsrError } from './runtime';
+export { getWsUrl } from './ws-url';

--- a/src/lib/utils/ws/shared/runtime.test.ts
+++ b/src/lib/utils/ws/shared/runtime.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ensureBrowser, isBrowser, isServer, WsSsrError } from './runtime';
+
+describe('ws runtime guard', () => {
+  it('detects browser environment under jsdom', () => {
+    expect(isBrowser()).toBe(true);
+    expect(isServer()).toBe(false);
+  });
+
+  it('ensureBrowser is a no-op in the browser', () => {
+    expect(() => ensureBrowser('connect')).not.toThrow();
+  });
+
+  describe('SSR simulation', () => {
+    const originalWindow = globalThis.window;
+
+    beforeEach(() => {
+      // @ts-expect-error — deleting for SSR simulation
+      delete globalThis.window;
+    });
+
+    afterEach(() => {
+      globalThis.window = originalWindow;
+    });
+
+    it('isBrowser returns false; isServer returns true', () => {
+      expect(isBrowser()).toBe(false);
+      expect(isServer()).toBe(true);
+    });
+
+    it('ensureBrowser throws a WsSsrError naming the calling method', () => {
+      try {
+        ensureBrowser('connect');
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(WsSsrError);
+        expect((err as WsSsrError).message).toMatch(/connect\(\) was called in a server context/);
+        expect((err as WsSsrError).code).toBe('WS_SSR_BLOCKED');
+      }
+    });
+  });
+});

--- a/src/lib/utils/ws/shared/runtime.ts
+++ b/src/lib/utils/ws/shared/runtime.ts
@@ -1,0 +1,35 @@
+/**
+ * Runtime guard for the WS layer.
+ *
+ * Unlike the HTTP layer, which silently no-ops on the server (no socket to
+ * open), the WS layer **throws** when invoked in a non-browser runtime.
+ * Opening a WebSocket from a Server Component, Server Action, or Route
+ * Handler is always a bug — surfacing it immediately is far kinder to the
+ * developer than letting the error reach production as "the socket
+ * mysteriously never connects."
+ *
+ * Use `ensureBrowser(method)` at every public client-side entry point.
+ */
+import { WS_LOCAL_ERROR_CODES } from '../constants';
+
+export const isBrowser = (): boolean => typeof window !== 'undefined';
+
+export const isServer = (): boolean => !isBrowser();
+
+export class WsSsrError extends Error {
+  readonly code = WS_LOCAL_ERROR_CODES.SSR_BLOCKED;
+
+  constructor(method: string) {
+    super(
+      `[ws] ${method}() was called in a server context. ` +
+        `WebSocket clients run in the browser only. ` +
+        `Move the call into a "use client" component, or guard it with typeof window !== 'undefined'.`,
+    );
+    this.name = 'WsSsrError';
+    Object.setPrototypeOf(this, WsSsrError.prototype);
+  }
+}
+
+export function ensureBrowser(method: string): void {
+  if (isServer()) throw new WsSsrError(method);
+}

--- a/src/lib/utils/ws/shared/ws-url.ts
+++ b/src/lib/utils/ws/shared/ws-url.ts
@@ -1,0 +1,28 @@
+import { env } from '@/lib/env';
+
+import { WS_NAMESPACE } from '../constants';
+
+/**
+ * Compose the WebSocket URL to connect to.
+ *
+ * Reuses `NEXT_PUBLIC_API_URL` so operators don't need a second env var —
+ * the WS layer talks to the same origin as the HTTP layer. We strip the
+ * scheme + any trailing `/api/v{n}` and append the namespace:
+ *
+ *   https://api.example.com           → https://api.example.com/ws
+ *   https://api.example.com/api/v1    → https://api.example.com/ws
+ *   (empty NEXT_PUBLIC_API_URL)       → /ws                  (same-origin)
+ *
+ * Socket.IO accepts both absolute URLs and origin-relative paths. Returning
+ * the namespace alone when no origin is configured keeps reverse-proxy
+ * deployments working without configuration drift.
+ */
+const TRAILING_API_PREFIX = /\/api\/v\d+\/?$/;
+
+export function getWsUrl(namespace: string = WS_NAMESPACE): string {
+  const raw = (env.NEXT_PUBLIC_API_URL ?? '').trim();
+  if (!raw) return namespace;
+
+  const stripped = raw.replace(/\/$/, '').replace(TRAILING_API_PREFIX, '');
+  return `${stripped}${namespace}`;
+}

--- a/src/lib/utils/ws/types/disconnect-reason.ts
+++ b/src/lib/utils/ws/types/disconnect-reason.ts
@@ -1,0 +1,37 @@
+/**
+ * Server-issued disconnect reasons, mirroring
+ * `WS_DISCONNECT_REASON` in the NestJS-starter backend
+ * (`src/infrastructure/websocket/websocket.constants.ts`).
+ *
+ * Clients must branch on the payload's `reconnectable: boolean` flag rather
+ * than on the reason string — the boolean is the contract; the reason is
+ * for logging / UX. The mapping is centralised in
+ * {@link isReconnectableReason} so it stays in sync if the backend adjusts
+ * the policy.
+ */
+export const WS_DISCONNECT_REASON = {
+  SESSION_REVOKED: 'session_revoked',
+  ROLES_CHANGED: 'roles_changed',
+  MAX_CONNECTIONS: 'max_connections',
+  SERVER_SHUTDOWN: 'server_shutdown',
+  RATE_LIMITED: 'rate_limited',
+  MAX_AGE: 'max_age',
+} as const;
+
+export type WsDisconnectReason = (typeof WS_DISCONNECT_REASON)[keyof typeof WS_DISCONNECT_REASON];
+
+const RECONNECTABLE: ReadonlySet<WsDisconnectReason> = new Set([
+  WS_DISCONNECT_REASON.SERVER_SHUTDOWN,
+  WS_DISCONNECT_REASON.ROLES_CHANGED,
+  WS_DISCONNECT_REASON.MAX_AGE,
+]);
+
+/**
+ * Whether the client should transparently reconnect after the given reason.
+ *
+ * Use as a defensive fallback only — the server stamps `reconnectable` on
+ * the payload, and that is the authoritative contract.
+ */
+export function isReconnectableReason(reason: WsDisconnectReason): boolean {
+  return RECONNECTABLE.has(reason);
+}

--- a/src/lib/utils/ws/types/events.ts
+++ b/src/lib/utils/ws/types/events.ts
@@ -1,0 +1,63 @@
+import type {
+  WsErrorPayload,
+  WsForceDisconnectPayload,
+  WsPongPayload,
+  WsPresencePayload,
+  WsPresenceStatusPayload,
+  WsTokenRenewedPayload,
+} from './payloads';
+
+/**
+ * Events the **client** sends to the server.
+ *
+ * Mirrors `ClientToServerEvents` in the NestJS-starter backend
+ * (`src/infrastructure/websocket/types/ws-events.interface.ts`). Keep these
+ * field-for-field aligned — the server's typed gateway will not deliver any
+ * event not declared in its map, and silent drift will fail at runtime
+ * rather than at compile time.
+ *
+ * Extend this interface in your own feature folders via TypeScript
+ * declaration merging if you add custom client→server events to a gateway:
+ *
+ * ```ts
+ * // src/features/chat/types/ws-events.ts
+ * declare module '@/lib/utils/ws' {
+ *   interface ClientToServerEvents {
+ *     'message:send': (payload: { roomId: string; content: string }) => void;
+ *   }
+ * }
+ * ```
+ */
+export interface ClientToServerEvents {
+  ping: (ack?: () => void) => void;
+  'auth:token:renew': (
+    payload: { refreshToken: string },
+    ack?: (result: { success: boolean; error?: WsErrorPayload }) => void,
+  ) => void;
+  'presence:subscribe': (payload: { userId: string }) => void;
+  'presence:unsubscribe': (payload: { userId: string }) => void;
+}
+
+/**
+ * Events the **server** sends to the client.
+ *
+ * Same alignment rule as {@link ClientToServerEvents}. Subscribe to these
+ * via `useWsEvent(event, handler)` — the handler argument is inferred from
+ * this interface, no manual casting required.
+ */
+export interface ServerToClientEvents {
+  pong: (payload: WsPongPayload) => void;
+  error: (payload: WsErrorPayload) => void;
+  'auth:error': (payload: WsErrorPayload) => void;
+  'auth:token:renewed': (payload: WsTokenRenewedPayload) => void;
+  'auth:force:disconnect': (payload: WsForceDisconnectPayload) => void;
+  'presence:online': (payload: WsPresencePayload) => void;
+  'presence:offline': (payload: WsPresencePayload) => void;
+  'presence:status': (payload: WsPresenceStatusPayload) => void;
+}
+
+/** Union of every event name the server can emit. */
+export type ServerEventName = keyof ServerToClientEvents;
+
+/** Union of every event name the client can emit. */
+export type ClientEventName = keyof ClientToServerEvents;

--- a/src/lib/utils/ws/types/index.ts
+++ b/src/lib/utils/ws/types/index.ts
@@ -1,0 +1,19 @@
+export {
+  isReconnectableReason,
+  WS_DISCONNECT_REASON,
+  type WsDisconnectReason,
+} from './disconnect-reason';
+export type {
+  ClientEventName,
+  ClientToServerEvents,
+  ServerEventName,
+  ServerToClientEvents,
+} from './events';
+export type {
+  WsErrorPayload,
+  WsForceDisconnectPayload,
+  WsPongPayload,
+  WsPresencePayload,
+  WsPresenceStatusPayload,
+  WsTokenRenewedPayload,
+} from './payloads';

--- a/src/lib/utils/ws/types/payloads.ts
+++ b/src/lib/utils/ws/types/payloads.ts
@@ -1,0 +1,44 @@
+import type { WsDisconnectReason } from './disconnect-reason';
+
+/**
+ * Application or auth error payload. Mirrors `WsErrorPayload` in the
+ * NestJS-starter backend and shares the same `{ key: message }` shape with
+ * `ApiException.errors` from the HTTP layer.
+ */
+export interface WsErrorPayload {
+  code: string;
+  message: string;
+  errors?: Record<string, string>[];
+  /** Present only in development mode. */
+  stack?: string;
+}
+
+export interface WsPresencePayload {
+  userId: string;
+  timestamp: number;
+}
+
+export interface WsPresenceStatusPayload {
+  userId: string;
+  status: 'online' | 'offline';
+  lastSeen?: number;
+}
+
+export interface WsTokenRenewedPayload {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}
+
+/**
+ * Server-initiated disconnect. **Branch on `reconnectable`, not on `reason`.**
+ * The boolean is the contract; the reason is for logging / UX.
+ */
+export interface WsForceDisconnectPayload {
+  reason: WsDisconnectReason;
+  reconnectable: boolean;
+}
+
+export interface WsPongPayload {
+  timestamp: number;
+}

--- a/src/providers/StoreProvider.tsx
+++ b/src/providers/StoreProvider.tsx
@@ -1,10 +1,11 @@
 'use client';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { Provider } from 'react-redux';
 import type { Persistor } from 'redux-persist';
 import { PersistGate } from 'redux-persist/integration/react';
 
+import { attachWsBridge, wsClient } from '@/lib/utils/ws';
 import { type AppState, type AppStore, makeStore } from '@/store';
 import { createPersistor } from '@/store/persistor';
 
@@ -21,6 +22,16 @@ export const StoreProvider = ({ children, preloadedState }: StoreProviderProps) 
     storeRef.current = makeStore(preloadedState);
     persistorRef.current = createPersistor(storeRef.current);
   }
+
+  // Bridge the WS client's lifecycle into the Redux slice exactly once per
+  // store instance. The bridge does not open a connection — that happens
+  // lazily on first `useWsEvent` subscription or an explicit `connect()`.
+  // Effect runs in the browser only, so the SSR boundary is safe.
+  useEffect(() => {
+    const store = storeRef.current;
+    if (!store) return;
+    return attachWsBridge(wsClient, store.dispatch);
+  }, []);
 
   return (
     <Provider store={storeRef.current}>

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -3,8 +3,17 @@ import { persistReducer } from 'redux-persist';
 
 import { countPersistConfig, counterReducer as countReducer } from '@/features/counter/store';
 
+import { wsReducer } from './slices/ws.slice';
+
+/**
+ * `ws` is intentionally NOT wrapped in `persistReducer` — connection state
+ * is ephemeral, and rehydrating "connected: true" on first paint would lie
+ * about the actual transport. The bridge dispatches the real status as
+ * soon as the WS client mounts.
+ */
 export const rootReducer = combineReducers({
   count: persistReducer(countPersistConfig, countReducer),
+  ws: wsReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/store/slices/ws.slice.test.ts
+++ b/src/store/slices/ws.slice.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { WS_DISCONNECT_REASON } from '@/lib/utils/ws';
+
+import {
+  wsConnectStarted,
+  wsErrored,
+  wsForceDisconnected,
+  wsReducer,
+  wsReset,
+  wsStatusChanged,
+} from './ws.slice';
+
+const initial = wsReducer(undefined, { type: '@@INIT' });
+
+describe('ws slice', () => {
+  it('defaults to idle / null fields', () => {
+    expect(initial.status).toBe('idle');
+    expect(initial.socketId).toBeNull();
+    expect(initial.lastError).toBeNull();
+    expect(initial.forceDisconnectReason).toBeNull();
+    expect(initial.reconnectable).toBeNull();
+    expect(initial.connectedAt).toBeNull();
+    expect(initial.anonymous).toBe(false);
+  });
+
+  it('statusChanged → connected stamps connectedAt and clears error / force fields', () => {
+    const dirty = wsReducer(
+      {
+        ...initial,
+        lastError: { code: 'X', message: 'x' },
+        forceDisconnectReason: WS_DISCONNECT_REASON.SESSION_REVOKED,
+        reconnectable: false,
+      },
+      wsStatusChanged({ status: 'connected', socketId: 'sock-1' }),
+    );
+    expect(dirty.status).toBe('connected');
+    expect(dirty.socketId).toBe('sock-1');
+    expect(dirty.connectedAt).toBeGreaterThan(0);
+    expect(dirty.lastError).toBeNull();
+    expect(dirty.forceDisconnectReason).toBeNull();
+    expect(dirty.reconnectable).toBeNull();
+  });
+
+  it('statusChanged → non-connected preserves prior error info', () => {
+    const next = wsReducer(
+      { ...initial, lastError: { code: 'X', message: 'x' } },
+      wsStatusChanged({ status: 'reconnecting', socketId: null }),
+    );
+    expect(next.lastError).toEqual({ code: 'X', message: 'x' });
+  });
+
+  it('errored stashes the payload', () => {
+    const next = wsReducer(initial, wsErrored({ code: 'BAD', message: 'boom' }));
+    expect(next.lastError).toEqual({ code: 'BAD', message: 'boom' });
+  });
+
+  it('forceDisconnected records reason and reconnectable flag', () => {
+    const next = wsReducer(
+      initial,
+      wsForceDisconnected({
+        reason: WS_DISCONNECT_REASON.SESSION_REVOKED,
+        reconnectable: false,
+      }),
+    );
+    expect(next.forceDisconnectReason).toBe(WS_DISCONNECT_REASON.SESSION_REVOKED);
+    expect(next.reconnectable).toBe(false);
+  });
+
+  it('connectStarted records anonymous flag', () => {
+    const next = wsReducer(initial, wsConnectStarted({ anonymous: true }));
+    expect(next.anonymous).toBe(true);
+  });
+
+  it('reset returns to initial', () => {
+    const dirty = wsReducer(
+      { ...initial, status: 'connected', socketId: 's', connectedAt: 1 },
+      wsReset(),
+    );
+    expect(dirty).toEqual(initial);
+  });
+});

--- a/src/store/slices/ws.slice.ts
+++ b/src/store/slices/ws.slice.ts
@@ -1,0 +1,97 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+import type { WsDisconnectReason, WsErrorPayload, WsStatus } from '@/lib/utils/ws';
+
+/**
+ * WebSocket **transport** state.
+ *
+ * Domain state (chat messages, notifications) belongs in feature slices,
+ * not here. This slice tracks only the connection itself: status, last
+ * error, force-disconnect reason, and the current socket id (for log
+ * grepping).
+ *
+ * **Intentionally NOT persisted** — connection state across page reloads
+ * is meaningless and would show stale info on first paint. Excluded from
+ * `redux-persist` via the rootReducer composition.
+ */
+export interface WsState {
+  status: WsStatus;
+  socketId: string | null;
+  /** Last application or auth error received. Cleared on next successful connect. */
+  lastError: WsErrorPayload | null;
+  /** Set when the server force-disconnects. Inspect alongside `reconnectable`. */
+  forceDisconnectReason: WsDisconnectReason | null;
+  /**
+   * Mirror of the force-disconnect payload's `reconnectable` flag. `null`
+   * means no force-disconnect has happened. `false` means the UI should
+   * show "you were signed out" and route to login.
+   */
+  reconnectable: boolean | null;
+  /** Unix ms of the most recent successful connect. */
+  connectedAt: number | null;
+  /**
+   * Whether the most recent (or in-flight) connect was anonymous. Persisted
+   * across reconnects so UI can tell apart "anonymous waiting for auth" from
+   * "logged-out and disconnected."
+   */
+  anonymous: boolean;
+}
+
+const initialState: WsState = {
+  status: 'idle',
+  socketId: null,
+  lastError: null,
+  forceDisconnectReason: null,
+  reconnectable: null,
+  connectedAt: null,
+  anonymous: false,
+};
+
+const wsSlice = createSlice({
+  name: 'ws',
+  initialState,
+  reducers: {
+    statusChanged: (
+      state,
+      action: PayloadAction<{ status: WsStatus; socketId: string | null }>,
+    ) => {
+      state.status = action.payload.status;
+      state.socketId = action.payload.socketId;
+      if (action.payload.status === 'connected') {
+        state.connectedAt = Date.now();
+        state.lastError = null;
+        state.forceDisconnectReason = null;
+        state.reconnectable = null;
+      }
+    },
+    socketIdChanged: (state, action: PayloadAction<string | null>) => {
+      state.socketId = action.payload;
+    },
+    errored: (state, action: PayloadAction<WsErrorPayload>) => {
+      state.lastError = action.payload;
+    },
+    forceDisconnected: (
+      state,
+      action: PayloadAction<{ reason: WsDisconnectReason; reconnectable: boolean }>,
+    ) => {
+      state.forceDisconnectReason = action.payload.reason;
+      state.reconnectable = action.payload.reconnectable;
+    },
+    connectStarted: (state, action: PayloadAction<{ anonymous: boolean }>) => {
+      state.anonymous = action.payload.anonymous;
+    },
+    reset: () => initialState,
+  },
+});
+
+export const {
+  statusChanged: wsStatusChanged,
+  socketIdChanged: wsSocketIdChanged,
+  errored: wsErrored,
+  forceDisconnected: wsForceDisconnected,
+  connectStarted: wsConnectStarted,
+  reset: wsReset,
+} = wsSlice.actions;
+
+export const wsReducer = wsSlice.reducer;
+export { wsSlice };

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,7 +1,24 @@
 import '@testing-library/jest-dom/vitest';
 
 import { cleanup } from '@testing-library/react';
-import { afterEach } from 'vitest';
+import { afterEach, vi } from 'vitest';
+
+// `react-secure-storage` constructs an `EncryptionService` at module load
+// that fingerprints the browser via `<canvas>.getContext`. jsdom doesn't
+// implement canvas, so the import explodes anywhere it's pulled in
+// transitively (HTTP token store, WS auth carrier, etc.). Stub it globally —
+// tests that need real behaviour are integration tests, not unit tests.
+vi.mock('react-secure-storage', () => {
+  const store = new Map<string, unknown>();
+  return {
+    default: {
+      setItem: (k: string, v: unknown) => store.set(k, v),
+      getItem: (k: string) => store.get(k) ?? null,
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+    },
+  };
+});
 
 afterEach(() => {
   cleanup();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1560,6 +1560,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@socket.io/component-emitter@npm:~3.1.0":
+  version: 3.1.2
+  resolution: "@socket.io/component-emitter@npm:3.1.2"
+  checksum: 10c0/c4242bad66f67e6f7b712733d25b43cbb9e19a595c8701c3ad99cbeb5901555f78b095e24852f862fffb43e96f1d8552e62def885ca82ae1bb05da3668fd87d7
+  languageName: node
+  linkType: hard
+
 "@standard-schema/spec@npm:^1.0.0":
   version: 1.0.0
   resolution: "@standard-schema/spec@npm:1.0.0"
@@ -2861,7 +2868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4.3.4, debug@npm:~4.4.1":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -3010,6 +3017,26 @@ __metadata:
   dependencies:
     once: "npm:^1.4.0"
   checksum: 10c0/b0701c92a10b89afb1cb45bf54a5292c6f008d744eb4382fa559d54775ff31617d1d7bc3ef617575f552e24fad2c7c1a1835948c66b3f3a4be0a6c1f35c883d8
+  languageName: node
+  linkType: hard
+
+"engine.io-client@npm:~6.6.1":
+  version: 6.6.4
+  resolution: "engine.io-client@npm:6.6.4"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.4.1"
+    engine.io-parser: "npm:~5.2.1"
+    ws: "npm:~8.18.3"
+    xmlhttprequest-ssl: "npm:~2.1.1"
+  checksum: 10c0/d90bc32d614f67db9c198d1c26a787529f3038a7429c75e677f5495938cc45f9e89d435e8860bcfcc01db410e21d2f245b914f2fcbdb03ffd50d30f2aeec5143
+  languageName: node
+  linkType: hard
+
+"engine.io-parser@npm:~5.2.1":
+  version: 5.2.3
+  resolution: "engine.io-parser@npm:5.2.3"
+  checksum: 10c0/ed4900d8dbef470ab3839ccf3bfa79ee518ea8277c7f1f2759e8c22a48f64e687ea5e474291394d0c94f84054749fd93f3ef0acb51fa2f5f234cc9d9d8e7c536
   languageName: node
   linkType: hard
 
@@ -5505,6 +5532,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"socket.io-client@npm:^4.8.3":
+  version: 4.8.3
+  resolution: "socket.io-client@npm:4.8.3"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.4.1"
+    engine.io-client: "npm:~6.6.1"
+    socket.io-parser: "npm:~4.2.4"
+  checksum: 10c0/76c0d86de0b636d0bf5011cf3425212c900f43dac632db6eb493816920cd035af7ddd92fea9a106b45eb347405953c0414eb3a5d465b180215e46fc8b61420b3
+  languageName: node
+  linkType: hard
+
+"socket.io-parser@npm:~4.2.4":
+  version: 4.2.6
+  resolution: "socket.io-parser@npm:4.2.6"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.4.1"
+  checksum: 10c0/ba0a0b541b0a8e9d02b45c04c4c93a02331be5ea3478073c65bb9ff87032f12469c9adb309728eb90c0a352618d645ab88999c167a11c783cac861d7fd35c9d1
+  languageName: node
+  linkType: hard
+
 "socks-proxy-agent@npm:^8.0.3":
   version: 8.0.5
   resolution: "socks-proxy-agent@npm:8.0.5"
@@ -5782,6 +5831,7 @@ __metadata:
     redux: "npm:^5.0.1"
     redux-persist: "npm:^6.0.0"
     server-only: "npm:^0.0.1"
+    socket.io-client: "npm:^4.8.3"
     tailwindcss: "npm:^4.3.0"
     tsx: "npm:^4.22.0"
     typescript: "npm:^6.0.3"
@@ -6334,6 +6384,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:~8.18.3":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
+  languageName: node
+  linkType: hard
+
 "xml-name-validator@npm:^5.0.0":
   version: 5.0.0
   resolution: "xml-name-validator@npm:5.0.0"
@@ -6345,6 +6410,13 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
+  languageName: node
+  linkType: hard
+
+"xmlhttprequest-ssl@npm:~2.1.1":
+  version: 2.1.2
+  resolution: "xmlhttprequest-ssl@npm:2.1.2"
+  checksum: 10c0/70d60869323e823f473a238f78fd108437edbc3690ecd5859c39c83217080090a18899b272e515769c0d1f518cc64cbed6b6995b23fdd7ba13b297d530b6e631
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds a typed Socket.IO client matching the NestJS-starter `/ws` gateway, following the same architectural pattern as the HTTP layer: shared foundation, default singleton + factory, Redux slice for transport state, three focused hooks, hard SSR boundary.

- **Types mirror the backend** verbatim (`ClientToServerEvents`, `ServerToClientEvents`, `WS_DISCONNECT_REASON`). Extend per feature via TypeScript declaration merging — example in the WS README.
- **Cookie-mode auth by default** (reuses `SAVE_AUTH_TOKENS`). Bearer-mode is a one-flag flip. Anonymous mode is explicit via `connect({ anonymous: true })`.
- **Reconnection policy honours the server's `reconnectable` boolean** — denial reasons (`session_revoked`, `max_connections`, `rate_limited`) latch fatal state and disable socket.io auto-reconnect; operational reasons (`roles_changed`, `max_age`, `server_shutdown`) reconnect transparently.
- **25 s application heartbeat** matches the backend's documented Redis TTL refresh cadence.
- **Lazy connect on first subscriber** — no socket opens at module load. The transport is dormant until a `useWsEvent` mounts.
- **Hard SSR boundary** — calling `wsClient.connect()` server-side throws `WsSsrError` rather than silently no-op'ing (HTTP's pattern is forgiving; WS isn't, because a WS call from SSR is always a bug).
- **Redux slice is ephemeral** — intentionally not wrapped in `persistReducer`. Connection status across reloads would lie.
- **socket.io-client@^4.8.3** added to dependencies (matches backend protocol version).

## Architecture

```
useWsStatus  ─reads─▶  ws Redux slice  ◀─dispatches─  attachWsBridge  ◀─lifecycle─  wsClient (singleton)
useWsEvent   ─talks to────────────────────────────────────────────────▶            (socket.io-client)
useWsEmit    ─talks to────────────────────────────────────────────────▶
```

Feature code imports from `@/lib/utils/ws` only. The `shared/`, `redux/bridge`, and `client/internals` paths are private.

## Test plan

- [x] `yarn ci:check` — Biome lint + format + import sort
- [x] `yarn type-check`
- [x] `yarn check:deprecated`
- [x] `yarn test` — 126 tests across 19 files (42 new this PR)
- [x] `yarn build` — production build green
- [x] Pre-commit + pre-push hooks pass
- [ ] CI green on this PR
- [ ] Smoke test against a running NestJS-starter backend (connect → presence subscribe → receive `presence:online`)

## Out of scope (deliberately)

- In-place token renewal via `auth:token:renew`. V1 cookie-mode disconnects/reconnects when access cookie expires (cheap, no UX hit). Bearer-mode renewal documented in the README as future work.
- Specific feature gateway implementations (chat, notifications, etc.). The transport + hooks + slice are infrastructure; gateway-specific code belongs in `features/<feature>/`.
- `next-maker` integration. This PR's WS code is the source-of-truth the `next-maker` `setup ws` command will copy from. The CLI manifest + setup service is a separate follow-up PR in the `npm-packages` repo.

## Notable design decisions

- **Why `WsClient` not a thin `socket.io-client` re-export?** Lifecycle is too involved (heartbeat, force-disc, reconnection policy, anonymous mode) to leave to consumers.
- **Why a singleton + factory, not just a factory?** The 90% case is one client per app. The Proxy-based lazy singleton mirrors `fetchClient` so users learn one pattern.
- **Why no `WsProvider` component?** Connection wiring is a side effect, not UI. `StoreProvider` runs `attachWsBridge` in an effect — no extra DOM nesting.
- **Why fail-fast SSR?** A `useWsEvent` call in an RSC is always a bug. Forgiving HTTP-style handling would hide it.

## Backend compatibility

This PR aligns with `nestjs-starter/docs/socket.md` end-to-end. The event maps, disconnect reasons, heartbeat cadence, force-disconnect semantics, and auth carrier paths all reference back to that doc.