### PR TITLE
docs: sync all docs with current code + remove empty scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,14 @@ Production-ready App Router template. Next 16, React 19, TypeScript, Tailwind v4
 
 - **Linter/formatter**: Biome only. No ESLint, no Prettier. Config: `biome.json`. Run `yarn lint` / `yarn lint:fix` / `yarn format`. CI uses `yarn ci:check` (`biome ci`).
 - **Tests**: Vitest + React Testing Library + jsdom. Co-locate as `*.test.tsx` next to the source file. Use `renderWithProviders` from `test/test-utils.tsx` when the component needs Redux/i18n. Run with `yarn test` (or `yarn test:watch` / `yarn test:coverage`).
-- **Env vars**: Always import from `@/lib/env` (zod-validated at module load), never `process.env.NEXT_PUBLIC_*` directly. Add new vars to the schema in `src/lib/env.ts` AND to `.env.example`.
+- **Env vars**: Always import from `@/lib/env` (zod-validated at module load), never `process.env.NEXT_PUBLIC_*` directly. Add new vars to the schema in `src/lib/env/schema.ts`, the reader in `src/lib/env/index.ts`, AND `.env.example`.
 - **Logging**: Import `logger` from `@/lib/logger` (pino) — never `console.*`. Attach context via `logger.child({ requestId, userId })`. Sensitive keys (token, password, authorization) are auto-redacted.
 - **Routing interception**: `src/proxy.ts` (Next 16 replacement for `middleware.ts`). Do NOT create `middleware.ts`.
-- **i18n**: `next-intl`. All user-facing routes live under `src/app/[locale]/`. Locale config in `src/i18n/routing.ts`; request config in `src/i18n/request.ts`.
-- **State**: Redux Toolkit + redux-persist. Store assembled in `src/store/`. Use typed hooks from `src/store/hooks.ts`, never raw `useDispatch`/`useSelector`.
+- **i18n**: `next-intl`. All user-facing routes live under `src/app/[locale]/`. Locale config in `src/i18n/routing.ts`; request config in `src/i18n/request.ts`. Locale types in `src/types/i18n.ts`.
+- **State**: Redux Toolkit + redux-persist. Store assembled in `src/store/`. Use typed hooks from `src/store/hooks.ts`, never raw `useDispatch`/`useSelector`. The `ws` slice (`src/store/slices/ws.slice.ts`) is ephemeral — not persisted.
 - **Theme**: `@teispace/next-themes` (drop-in replacement for the unmaintained `next-themes`). Provider in `src/providers/CustomThemeProvider.tsx`.
-- **HTTP**: axios wrapper in `src/services/api/`. Errors via `src/lib/errors/`.
+- **HTTP**: Dual clients (`fetchClient`, `axiosClient`) in `src/lib/utils/http/`. Universal entry is `@/lib/utils/http`; Server Components needing cookie forwarding import from `@/lib/utils/http/server`. Errors as typed `ApiException` from `src/lib/errors/` — clients never throw, returns land in `Either<ApiException, T>`. See `src/lib/utils/http/README.md`.
+- **WebSocket**: Typed Socket.IO client in `src/lib/utils/ws/`. Import from `@/lib/utils/ws` only — `shared/`, `client/internals`, and `redux/bridge` are private. Browser-only; opening a socket from a Server Component throws. See `src/lib/utils/ws/README.md`.
 - **Secure storage**: `react-secure-storage` wrapped in `src/services/storage/secure-storage.service.ts`. Never call the library directly.
 - **Import alias**: `@/*` → `src/*`.
 
@@ -26,18 +27,27 @@ Production-ready App Router template. Next 16, React 19, TypeScript, Tailwind v4
 
 ```
 src/
-  app/              App Router (root-level pages: robots.ts, sitemap.ts, global-error.tsx)
-  app/[locale]/     Localized routes
+  app/              App Router (root-level pages: robots.ts, sitemap.ts, global-error.tsx, not-found.tsx)
+  app/[locale]/     Localized routes (layout, page, error, not-found)
   components/       Shared, cross-feature components
   features/         Feature folders (components/, hooks/, store/, types/) — see features/README.md
-  i18n/             next-intl config
-  lib/              config, enums, errors, utils, validations
-  providers/        Root + nested React providers
-  proxy.ts          Edge proxy (Next 16 style; was middleware.ts)
-  services/         api, storage
-  store/            Redux store, persistor, hooks, rootReducer
+  i18n/             next-intl config (routing, request, navigation, translations/)
+  lib/
+    config/         API base, app paths, locales, constants, SEO
+    enums/          Cross-cutting enums (Environment, ...)
+    env/            Zod-validated env schema + cached loader
+    errors/         ApiException + catch helpers
+    logger/         Pino logger + redaction constants
+    utils/
+      http/         Dual HTTP clients on a shared foundation (universal + server entries)
+      ws/           Typed Socket.IO client + hooks + Redux bridge
+    validations/    Reusable zod schemas
+  providers/        RootProvider (the only advertised mount point) + Store/Theme providers
+  proxy.ts          Edge proxy (Next 16 replacement for middleware.ts)
+  services/storage/ react-secure-storage wrapper
+  store/            Redux store, persistor, hooks, rootReducer, slices/, SSR-safe storage
   styles/           Global CSS
-  types/            Shared TS types (common/, utility/)
+  types/            Shared TS types (common/, utility/, i18n)
 ```
 
 ## Conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **HTTP layer overhaul (`src/lib/utils/http/`)**: dual `fetchClient` / `axiosClient` on a shared foundation (`shared/` — request-id, response-parser, runtime, search-params). Cookie-mode auth by default with a one-flag flip to bearer; automatic `X-Request-Id` correlation; backend-compatible response envelope; offset and cursor pagination types; typed `{ params }` query objects (no manual `URLSearchParams`); single `parseApiError` pipeline; `createFetchClient` / `createAxiosClient` factories for custom upstreams. See `src/lib/utils/http/README.md`.
+- **HTTP universal/server entry split**: `@/lib/utils/http` is universal (browser/RSC-safe), `@/lib/utils/http/server` is server-only and forwards cookies via `next/headers`. The split keeps `next/headers` out of the client bundle and uses `server-only` to fail the build if violated. A `'use client'` regression sentinel (`__bundle-sentinel__/`) is mounted from `app/[locale]/layout.tsx` to catch leaks at build time.
+- **WebSocket layer (`src/lib/utils/ws/`)**: typed Socket.IO client matching the NestJS-starter `/ws` gateway. Cookie/bearer auth, application-level heartbeat, reconnection with `auth:force:disconnect` policy enforcement, anonymous-mode opt-in, hard SSR boundary (`WsSsrError`). React hooks (`useWsStatus`, `useWsEvent`, `useWsEmit`) with lazy connect on first subscribe. Connection state mirrored into a non-persisted Redux slice (`src/store/slices/ws.slice.ts`) via `attachWsBridge`. See `src/lib/utils/ws/README.md`.
+- **Co-located unit tests** for the HTTP and WS layers — `*.test.ts(x)` next to the source. `test/setup.ts` stubs `react-secure-storage` (canvas-free) and `server-only` (no-op) so unit tests can reach server-side modules.
+
+### Removed
+
+- Empty scaffolding directories (`src/features/auth/`, `src/features/dashboard/`, `src/app/[locale]/auth/`, `src/app/[locale]/dashboard/`, `src/app/auth/`, `src/services/api/`). They had no real code and were drifting away from what the docs described.
+
 ### Changed
 
 - **Tooling**: Replaced ESLint + Prettier + `prettier-plugin-tailwindcss` with [Biome](https://biomejs.dev) (`@biomejs/biome`). One tool now handles linting, formatting, and import sorting. Dropped `eslint.config.mjs`, `.prettierrc`, `.prettierignore`; added `biome.json`. CI runs a single `biome ci` step. Existing code style preserved (single quotes, semicolons, 100-col, trailing commas, LF).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,25 +35,26 @@ yarn install
 ### 3. Create a Feature Branch
 
 ```bash
-# Update your local main/develop branch
-git checkout develop
-git pull upstream develop
+# Sync your local main with upstream
+git checkout main
+git pull upstream main
 
-# Create a new feature branch
+# Create a new branch off main
 git checkout -b feat/your-feature-name
 ```
 
 ## 🌳 Branching Strategy
 
-We follow a Git Flow-inspired branching model:
+Trunk-based: `main` is the only long-lived branch. Short-lived feature/fix branches are cut from `main` and merged back via PR.
 
-- **`main`** – Production-ready code
-- **`develop`** – Integration branch for features
-- **`feat/*`** – New features
-- **`fix/*`** – Bug fixes
-- **`docs/*`** – Documentation updates
-- **`chore/*`** – Maintenance tasks
-- **`refactor/*`** – Code refactoring
+- **`main`** – production-ready trunk; all PRs target this
+- **`feat/*`** – new features
+- **`fix/*`** – bug fixes
+- **`docs/*`** – documentation-only updates
+- **`chore/*`** – maintenance / dependency work
+- **`refactor/*`** – non-functional restructuring
+
+CI runs on every push and PR to `main`.
 
 ## 📝 Commit Convention
 
@@ -112,14 +113,22 @@ On every commit, the following checks run automatically via Husky hooks:
 
 #### Pre-commit Hook
 
-- **Lint-staged**: Runs `biome check --write` on staged files only (single command lints, formats, and sorts imports)
-- **Pre-commit**: Syncs `.env.example`, validates staged files with lint-staged, then type-checks any staged TypeScript
-- **Pre-push**: Runs full validation (`yarn validate`: `biome ci` + type-check + build) before pushing
-- Auto-fixes formatting, linting, and import-order issues where possible
+- Verifies `.env.example` is in sync with `.env` (`yarn env:sync --check`)
+- Runs `lint-staged`, which executes `biome check --write` on staged files (single command lints, formats, sorts imports)
+- If any TypeScript files are staged, runs `yarn type-check` (`tsc --noEmit`) on the whole project
+
+#### Pre-push Hook
+
+- `yarn ci:check` (the same `biome ci` CI runs)
+- `yarn type-check`
+- `yarn check:deprecated`
+- `yarn test` (Vitest run)
+
+The production build is left to CI — pre-push deliberately skips it to keep the wait short.
 
 #### Commit-msg Hook
 
-- **Commitlint**: Validates commit message format
+- **Commitlint**: validates commit message format
 - Ensures commits follow Conventional Commits specification
 
 ### Manual Checks
@@ -157,17 +166,21 @@ yarn validate
 
 ## 🧪 Testing
 
-Currently, the test framework is not configured. When adding tests:
+Vitest + React Testing Library + jsdom are wired up. Co-locate tests as `*.test.ts(x)` next to the source file. Use `renderWithProviders` from `test/test-utils.tsx` when your component needs Redux/i18n.
 
 ```bash
-yarn test
+yarn test            # one-shot run (also what CI executes)
+yarn test:watch      # watch mode for local dev
+yarn test:coverage   # v8 coverage report
 ```
+
+Global setup (jsdom polyfills, `react-secure-storage` and `server-only` stubs) lives in `test/setup.ts`.
 
 ## 🔧 Development Workflow
 
 ### Step-by-Step Guide
 
-1. **Create a branch** from `develop`:
+1. **Create a branch** from `main`:
 
    ```bash
    git checkout -b feat/amazing-feature
@@ -221,12 +234,12 @@ When you run `git commit` or `yarn commit`:
 ### Before Submitting
 
 - [ ] All commits follow Conventional Commits format
-- [ ] Code passes all linting checks (`yarn lint`)
-- [ ] Code is properly formatted (`yarn format:check`)
-- [ ] TypeScript types are correct (`yarn type-check`)
-- [ ] Build succeeds (`yarn build`)
-- [ ] No console.log or debugging code left behind
-- [ ] Self-review of your own code
+- [ ] `yarn ci:check` passes (lint + format + import sort)
+- [ ] `yarn type-check` passes
+- [ ] `yarn check:deprecated` passes
+- [ ] `yarn test` passes (add tests for new behaviour)
+- [ ] No `console.*` or debugging code left behind (use `logger` from `@/lib/logger`)
+- [ ] Self-review of your own diff
 
 ### PR Title Format
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ nextjs-starter/
 │  ├─ components/               # Shared UI components and barrels
 │  ├─ features/                 # Feature-driven modules (counter example)
 │  ├─ i18n/                     # Internationalization (translations + routing)
-│  ├─ lib/                      # Config, env, logger, errors, http clients, utils, validations
+│  ├─ lib/                      # Config, env, logger, errors, http + ws clients, utils, validations
 │  ├─ providers/                # React providers (root/store/theme)
-│  ├─ services/                 # API & storage services
-│  ├─ store/                    # Redux store, persistor, typed hooks, SSR-safe storage
+│  ├─ services/storage/         # react-secure-storage wrapper
+│  ├─ store/                    # Redux store, persistor, typed hooks, slices/, SSR-safe storage
 │  ├─ styles/                   # Global CSS / Tailwind
 │  ├─ types/                    # Global TypeScript types
 │  └─ proxy.ts                  # Next 16 edge proxy (replaces middleware.ts)
@@ -79,14 +79,17 @@ cp .env.example .env
 
 | Variable               | Description                                                                        | Default                 |
 | :--------------------- | :--------------------------------------------------------------------------------- | :---------------------- |
+| `NODE_ENV`             | `development` \| `test` \| `production`. Drives the logger transport, build output, and a few feature flags. | `development`           |
 | `NEXT_PUBLIC_API_URL`  | Bare origin of the backing API (e.g. `https://api.example.com`). The `/api/v{n}` URI-version prefix is appended internally — do not include it here. Empty → relative/proxied requests. | `(empty)`               |
 | `NEXT_PUBLIC_APP_URL`  | Public URL this app is served from (used for OG/canonical URLs).                   | `http://localhost:3000` |
 | `DEFAULT_TIMEZONE`     | IANA time zone for server-rendered date formatting. Keeps SSR deterministic.       | `UTC`                   |
 | `DEFAULT_LOCALE`       | Fallback locale when a request locale cannot be resolved.                          | `en`                    |
-| `PORT`                 | Port to run the server on                                                          | `3000`                  |
-| `CONTAINER_NAME`       | Name of the Docker container                                                       | `next-app`              |
-| `IMAGE_NAME`           | Name of the Docker image                                                           | `nextjs-starter`        |
-| `IMAGE_TAG`            | Tag for the Docker image                                                           | `latest`                |
+| `PORT`                 | Port to run the server on.                                                         | `3000`                  |
+| `CONTAINER_NAME`       | Name of the Docker container.                                                      | `next-app`              |
+| `IMAGE_NAME`           | Name of the Docker image.                                                          | `nextjs-starter`        |
+| `IMAGE_TAG`            | Tag for the Docker image.                                                          | `latest`                |
+
+> Adding a new env var? Update three places: `src/lib/env/schema.ts` (zod schema), `src/lib/env/index.ts` (`readRawEnv`), and `.env.example`. The pre-commit hook keeps `.env.example` in sync via `yarn env:sync --check`.
 
 ### Internationalization
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -9,13 +9,13 @@ nextjs-starter/
 ├── .github/                                    # GitHub configuration
 │   ├── ISSUE_TEMPLATE/                         # Issue templates
 │   │   ├── bug_report.md
-│   │   ├── config.yml
 │   │   ├── documentation.md
 │   │   ├── feature_request.md
 │   │   └── question.md
 │   ├── workflows/                              # GitHub Actions workflows
-│   │   └── ci.yml                              # CI/CD pipeline (biome ci + type-check + build)
-│   ├── dependabot.yml                          # Dependabot configuration
+│   │   ├── ci.yml                              # ci:check + type-check + check:deprecated + test + build
+│   │   └── dependabot-auto-merge.yml           # Auto-merge green patch/minor Dependabot PRs
+│   ├── dependabot.yml                          # Dependabot configuration (grouped minor+patch)
 │   └── PULL_REQUEST_TEMPLATE.md                # Pull request template
 │
 ├── .husky/                                     # Git hooks
@@ -59,7 +59,9 @@ nextjs-starter/
 │   │
 │   ├── features/                               # Feature-based modules
 │   │   ├── counter/                            # Counter feature example
-│   │   │   ├── components/Counter.tsx
+│   │   │   ├── components/
+│   │   │   │   ├── Counter.tsx
+│   │   │   │   └── Counter.test.tsx
 │   │   │   ├── hooks/useCounter.ts
 │   │   │   ├── store/                          # Redux slice, selectors, persist config
 │   │   │   │   ├── counter.selectors.ts
@@ -104,25 +106,35 @@ nextjs-starter/
 │   │   │   ├── http/                           # HTTP clients (backend-compatible transport)
 │   │   │   │   ├── shared/                     # Universal foundation (client-bundle-safe)
 │   │   │   │   │   ├── request-id.ts           # X-Request-Id generation + extractors
+│   │   │   │   │   ├── request-id.test.ts
 │   │   │   │   │   ├── response-parser.ts      # Single parseApiError for both clients
+│   │   │   │   │   ├── response-parser.test.ts
 │   │   │   │   │   ├── runtime.ts              # isBrowser / isServer
+│   │   │   │   │   ├── runtime.test.ts
 │   │   │   │   │   ├── search-params.ts        # Typed query object → URLSearchParams
+│   │   │   │   │   ├── search-params.test.ts
 │   │   │   │   │   └── index.ts
 │   │   │   │   ├── axios-client/               # Axios adapter on the shared foundation
 │   │   │   │   │   ├── axios-client.ts
-│   │   │   │   │   ├── client.ts
+│   │   │   │   │   ├── axios-client.test.ts
+│   │   │   │   │   ├── client.ts               # Default singleton (universal entry)
 │   │   │   │   │   ├── index.ts
 │   │   │   │   │   ├── interceptors.ts         # Accepts optional CookieResolver
-│   │   │   │   │   └── token-refresh.ts
+│   │   │   │   │   ├── token-refresh.ts
+│   │   │   │   │   └── token-refresh.test.ts
 │   │   │   │   ├── fetch-client/               # Fetch adapter on the shared foundation
-│   │   │   │   │   ├── client.ts
+│   │   │   │   │   ├── client.ts               # Default singleton (universal entry)
 │   │   │   │   │   ├── fetch-client.ts
+│   │   │   │   │   ├── fetch-client.test.ts
 │   │   │   │   │   ├── index.ts
 │   │   │   │   │   ├── interceptors.ts         # Accepts optional CookieResolver
-│   │   │   │   │   └── token-refresh.ts
+│   │   │   │   │   ├── interceptors.test.ts
+│   │   │   │   │   ├── token-refresh.ts
+│   │   │   │   │   └── token-refresh.test.ts
 │   │   │   │   ├── __bundle-sentinel__/        # `'use client'` regression gate — do not delete
 │   │   │   │   │   └── client-bundle-sentinel.tsx
 │   │   │   │   ├── client-utils.ts             # TokenRefreshManager + helpers
+│   │   │   │   ├── client-utils.test.ts
 │   │   │   │   ├── index.ts                    # Universal entry: fetchClient, axiosClient, toSearchParams
 │   │   │   │   ├── server.ts                   # Server-only entry: same shape + next/headers cookies
 │   │   │   │   ├── token-store.ts              # secureStorageTokenStore (inert in cookie-mode)
@@ -135,24 +147,32 @@ nextjs-starter/
 │   │   │   │   │   └── index.ts
 │   │   │   │   ├── shared/                     # Internal: runtime, auth-carrier, URL composer
 │   │   │   │   │   ├── runtime.ts              # isBrowser + WsSsrError (hard SSR guard)
+│   │   │   │   │   ├── runtime.test.ts
 │   │   │   │   │   ├── auth-carrier.ts         # buildHandshakeAuth (cookie vs bearer)
 │   │   │   │   │   ├── ws-url.ts               # getWsUrl (origin + namespace)
 │   │   │   │   │   └── index.ts
 │   │   │   │   ├── client/                     # WsClient class + default singleton
 │   │   │   │   │   ├── ws-client.ts            # Lifecycle, heartbeat, force-disconnect
+│   │   │   │   │   ├── ws-client.test.ts
 │   │   │   │   │   ├── client.ts               # `wsClient` lazy proxy singleton
 │   │   │   │   │   ├── lifecycle-emitter.ts    # Internal typed event emitter
 │   │   │   │   │   ├── types.ts                # WsStatus, WsClientOptions, WsConnectOptions
 │   │   │   │   │   └── index.ts
 │   │   │   │   ├── redux/                      # Bridge + selectors (slice lives in store/slices)
 │   │   │   │   │   ├── bridge.ts               # attachWsBridge — only path that dispatches to ws slice
+│   │   │   │   │   ├── bridge.test.ts
 │   │   │   │   │   ├── selectors.ts            # selectWsStatus, selectWsIsConnected, ...
 │   │   │   │   │   └── index.ts
 │   │   │   │   ├── hooks/                      # React hooks
 │   │   │   │   │   ├── use-ws-status.ts        # Read connection state from Redux
+│   │   │   │   │   ├── use-ws-status.test.tsx
 │   │   │   │   │   ├── use-ws-event.ts         # Subscribe with lazy connect on first mount
+│   │   │   │   │   ├── use-ws-event.test.tsx
 │   │   │   │   │   ├── use-ws-emit.ts          # Typed emit accessor
+│   │   │   │   │   ├── use-ws-emit.test.tsx
 │   │   │   │   │   └── index.ts
+│   │   │   │   ├── __test-utils__/             # FakeSocket helper used by WS unit tests
+│   │   │   │   │   └── fake-socket.ts
 │   │   │   │   ├── constants.ts                # WS_NAMESPACE, WS_HEARTBEAT_INTERVAL_MS, etc.
 │   │   │   │   ├── index.ts                    # Public surface
 │   │   │   │   └── README.md
@@ -167,8 +187,6 @@ nextjs-starter/
 │   │   └── index.ts
 │   │
 │   ├── services/                               # Service layer
-│   │   ├── api/
-│   │   │   └── index.ts
 │   │   └── storage/                            # Storage services
 │   │       ├── index.ts
 │   │       └── secure-storage.service.ts       # react-secure-storage wrapper
@@ -179,7 +197,8 @@ nextjs-starter/
 │   │   ├── persistor.ts                        # Redux-persist setup
 │   │   ├── rootReducer.ts                      # Root reducer (ws slice NOT persisted)
 │   │   ├── slices/
-│   │   │   └── ws.slice.ts                     # WebSocket connection state (ephemeral)
+│   │   │   ├── ws.slice.ts                     # WebSocket connection state (ephemeral)
+│   │   │   └── ws.slice.test.ts
 │   │   └── storage.ts                          # SSR-safe storage (noop on server, localStorage on client)
 │   │
 │   ├── styles/
@@ -203,6 +222,10 @@ nextjs-starter/
 ├── scripts/
 │   ├── sync-env.ts                             # Keeps .env.example in sync with .env
 │   └── check-deprecated.ts                     # Fails if any code uses an @deprecated API
+│
+├── test/                                       # Vitest setup + RTL helpers
+│   ├── setup.ts                                # Global mocks (react-secure-storage, server-only)
+│   └── test-utils.tsx                          # renderWithProviders + TestProviders
 │
 ├── .czrc                                       # Commitizen configuration
 ├── .dockerignore                               # Docker ignore patterns
@@ -278,7 +301,7 @@ Edge proxy for request interception (Next 16 replacement for `middleware.ts`).
 
 ### `src/services/`
 
-Service layer for API calls and storage operations, providing abstraction over data fetching and persistence. Storage is wrapped around `react-secure-storage`.
+Service layer for storage abstractions. Currently a thin wrapper around `react-secure-storage` (`storage/secure-storage.service.ts`). HTTP and WebSocket transports live under `src/lib/utils/`, not here — `services/` is for code that wraps an external SDK or persistence layer.
 
 ### `src/store/`
 
@@ -305,4 +328,6 @@ Centralized TypeScript type definitions including common types, utility types (E
 - Feature development guide: `src/features/README.md`
 - Internationalization setup: `src/i18n/README.md`
 - HTTP client documentation: `src/lib/utils/http/README.md`
+- WebSocket client documentation: `src/lib/utils/ws/README.md`
 - Contributing guidelines: `CONTRIBUTING.md`
+- Changelog: `CHANGELOG.md`

--- a/src/features/README.md
+++ b/src/features/README.md
@@ -1,50 +1,45 @@
 # Feature-Based Architecture
 
-This project follows a **Domain-Driven Design (DDD)** inspired feature-based architecture. This structure helps in scaling the application by keeping related code together, making it easier to maintain and test.
+This project follows a **Domain-Driven Design (DDD)** inspired feature-based architecture. Group code by feature, not by technical type — so everything an "auth" or "users" feature needs lives together and ships together.
 
 ## 📂 Structure
 
-Each feature is a self-contained module located in `src/features/`.
+Each feature is a self-contained module under `src/features/`. The shipped reference is `src/features/counter/` — copy its layout when you add a new feature.
 
 ```
 src/features/
-├── auth/                   # Feature name (e.g., auth, users, projects)
-│   ├── components/         # UI components specific to this feature
-│   │   ├── login-form.tsx
-│   │   └── register-form.tsx
-│   ├── hooks/              # React hooks specific to this feature
-│   │   └── use-auth.ts
-│   ├── services/           # API services specific to this feature (optional)
-│   │   └── auth.service.ts
-│   ├── store/              # Redux slices specific to this feature (optional)
-│   │   └── auth.slice.ts
-│   ├── types.ts            # TypeScript types/interfaces for this feature
-│   └── index.ts            # Public API (exports) of the feature
-└── ...
+└── counter/                  # Feature name (kebab-case folder)
+    ├── components/           # UI components specific to this feature
+    │   ├── Counter.tsx
+    │   └── Counter.test.tsx  # Co-located test
+    ├── hooks/                # React hooks specific to this feature
+    │   └── useCounter.ts
+    ├── store/                # Redux slice/selectors/persist (optional)
+    │   ├── counter.slice.ts
+    │   ├── counter.selectors.ts
+    │   ├── persist.ts        # Per-feature redux-persist config
+    │   └── index.ts          # Barrel re-export for `@/store/rootReducer`
+    ├── types/                # Feature-local TypeScript types
+    │   └── counter.types.ts
+    └── index.ts              # Public API — only what's safe to import from outside
 ```
+
+Optional subfolders you can add when the feature needs them: `services/` (API/SDK wrappers), `providers/` (feature-scoped React providers), `hoc/`. **Skip the folder if it has no files** — empty placeholders rot fast.
 
 ## 🚀 Creating a New Feature
 
-1.  **Create the folder structure**:
-    Create a new folder in `src/features/` with the name of your feature (e.g., `products`).
+1.  **Create the folder** under `src/features/` (e.g., `products`).
+2.  **Components** go in `src/features/products/components/`. Co-locate tests as `*.test.tsx`.
+3.  **Hooks** go in `src/features/products/hooks/`.
+4.  **Types** go in `src/features/products/types/<name>.types.ts`.
+5.  **Redux** (if the feature owns state) goes in `src/features/products/store/`. Wire the reducer into `src/store/rootReducer.ts`. Persist via the feature's own `persist.ts` so persistence config travels with the feature.
+6.  **Public API** — re-export from `src/features/products/index.ts`. Only export what other features / the `app/` layer needs.
 
-2.  **Add Components**:
-    Place your feature-specific components in `src/features/products/components/`.
-
-3.  **Add Hooks**:
-    Place your feature-specific hooks in `src/features/products/hooks/`.
-
-4.  **Define Types**:
-    Define your interfaces and types in `src/features/products/types.ts`.
-
-5.  **Export Public API**:
-    Use `src/features/products/index.ts` to export only what should be accessible from outside the feature.
-
-    ```typescript
+    ```ts
     // src/features/products/index.ts
     export * from './components/product-list';
     export * from './hooks/use-products';
-    export * from './types';
+    export * from './types/products.types';
     ```
 
 ## 🤝 Rules of Engagement
@@ -61,22 +56,22 @@ src/features/
 4.  **App Layer**:
     The `src/app` directory (Next.js App Router) should primarily compose features together. It should contain minimal business logic.
 
-## 📝 Example: Auth Feature
+## 📝 Sketch: an auth feature
 
-**`src/features/auth/types.ts`**
+**`src/features/auth/types/auth.types.ts`**
 
-```typescript
+```ts
 export interface User {
   id: string;
   email: string;
 }
 ```
 
-**`src/features/auth/hooks/use-auth.ts`**
+**`src/features/auth/hooks/useAuth.ts`**
 
-```typescript
+```ts
 import { useState } from 'react';
-import { User } from '../types';
+import type { User } from '../types/auth.types';
 
 export function useAuth() {
   const [user, setUser] = useState<User | null>(null);
@@ -85,28 +80,28 @@ export function useAuth() {
 }
 ```
 
-**`src/features/auth/components/login-form.tsx`**
+**`src/features/auth/components/LoginForm.tsx`**
 
-```typescript
-import { useAuth } from '../hooks/use-auth';
+```tsx
+import { useAuth } from '../hooks/useAuth';
 
 export function LoginForm() {
-  const { login } = useAuth();
-  return <form>...</form>;
+  const { user } = useAuth();
+  return <form>{/* ... */}</form>;
 }
 ```
 
 **`src/features/auth/index.ts`**
 
-```typescript
-export * from './components/login-form';
-export * from './hooks/use-auth';
-export * from './types';
+```ts
+export * from './components/LoginForm';
+export * from './hooks/useAuth';
+export type { User } from './types/auth.types';
 ```
 
 **Usage in `src/app/[locale]/login/page.tsx`**
 
-```typescript
+```tsx
 import { LoginForm } from '@/features/auth';
 
 export default function LoginPage() {
@@ -114,25 +109,4 @@ export default function LoginPage() {
 }
 ```
 
-## Example: Counter Feature
-
-This is an example layout for the `counter` feature showing feature-local store artifacts.
-
-```
-src/features/
-└── counter/
-    ├── components/
-    │   └── Counter.tsx
-    ├── hooks/
-    │   └── useCounter.ts
-    ├── services/
-    │   └── counter.api.ts
-    ├── store/
-    │   ├── counter.slice.ts
-    │   ├── persist.ts
-    │   └── counter.selectors.ts
-    └── types/
-        └── counter.types.ts
-```
-
-Import feature exports from the feature's public API (preferred) or import specific internals when necessary.
+For a working example with state + persistence, see `src/features/counter/`.

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -8,13 +8,14 @@ Quick reference for using **next-intl** in this project.
 
 ```
 src/i18n/
-├── types.ts            # TypeScript types (SupportedLocale, AppLocale)
-├── routing.ts          # Route config (locales, defaultLocale)
-├── request.ts          # Server-side config (loads translations)
+├── routing.ts          # Route config (locales, defaultLocale, localePrefix)
+├── request.ts          # Server-side config (loads translations, reads timeZone from env)
 ├── navigation.ts       # Locale-aware Link, redirect, useRouter
 └── translations/
     └── en.json         # Translation files
 ```
+
+Locale types (`SupportedLocale`, `AppLocale`, `LocaleDirection`) live in `src/types/i18n.ts` alongside the `next-intl` `AppConfig` module augmentation. The list of locales and their metadata lives in `src/lib/config/app-locales.ts` — `routing.ts` reads from there.
 
 ---
 
@@ -73,8 +74,6 @@ export default function ClientComponent() {
 
 ---
 
----
-
 ## 🎯 Static Rendering (SSG)
 
 **Required in EVERY page/layout:**
@@ -130,8 +129,6 @@ function Nav() {
 
 ---
 
----
-
 ## 🌐 Adding New Locale
 
 **1. Create translation file:**
@@ -143,7 +140,7 @@ cp src/i18n/translations/en.json src/i18n/translations/es.json
 **2. Update types:**
 
 ```ts
-// src/i18n/types.ts
+// src/types/i18n.ts
 export type SupportedLocale = 'en' | 'es';
 ```
 
@@ -169,8 +166,6 @@ locales: ['en', 'es'];
 ```bash
 yarn build
 ```
-
----
 
 ---
 
@@ -226,14 +221,13 @@ export async function generateMetadata({ params }) {
 
 ### Server Actions
 
-````tsx
+```tsx
 export async function submitForm(formData: FormData) {
   'use server';
   const t = await getTranslations('Forms');
   console.log(t('submitting'));
 }
-
----
+```
 
 ---
 
@@ -262,4 +256,4 @@ setRequestLocale(locale as 'en');  // Cast it
 
 ---
 
-**Version:** next-intl 4.5.3 | Next.js 16.0.3
+**Versions are tracked in `package.json` — this guide targets `next-intl ^4.12` on Next 16.**


### PR DESCRIPTION
## Summary

A full audit of every doc in the repo against the actual source. Several had drifted enough to mislead a new contributor or a coding agent — most notably AGENTS.md pointing at the wrong env/HTTP paths, CONTRIBUTING.md claiming the test framework wasn't configured, and structure.md missing files that now exist. This PR brings them all back into sync and deletes empty scaffolding directories that no code imported.

### Docs synced to current code

- **`AGENTS.md`** — corrected env path (`src/lib/env.ts` → `src/lib/env/` directory), corrected HTTP location (`src/services/api/` → `src/lib/utils/http/`), added a missing WebSocket bullet, expanded the directory layout to reflect today's `lib/utils/{http,ws}`, `lib/env`, `lib/logger`, and the ephemeral `ws` slice.
- **`README.md`** — added `NODE_ENV` to the env table, dropped the empty `services/api` mention from the short tree, added a "three places to update when adding an env var" hint.
- **`docs/structure.md`** — rewrote the HTTP/WS subtrees to include co-located `*.test.*` files, added `test/` and `dependabot-auto-merge.yml`, removed the deleted `services/api` branch, refreshed the `services/` description.
- **`CONTRIBUTING.md`** — replaced "tests not configured" with the real Vitest setup, corrected pre-commit/pre-push descriptions to match the actual hook scripts, rewrote Git-Flow as trunk-based (the repo only has `main`), refreshed the PR checklist to use the real gate commands.
- **`CHANGELOG.md`** — logged the recent HTTP overhaul, universal/server entry split, WS layer, co-located tests, and the scaffolding cleanup.
- **`src/features/README.md`** — replaced the stale `auth/`-folder example tree with the real `counter/` layout, deduped the duplicate "Counter Feature" block at the bottom, rewrote "Creating a New Feature" to match the actual conventions (`types/<name>.types.ts`, feature-local `persist.ts`, "skip empty folders").
- **`src/i18n/README.md`** — fixed the wrong types path (lives in `src/types/i18n.ts`, not `src/i18n/types.ts`), replaced the hard-coded version line with a pointer to `package.json`, fixed a broken code fence (`` ```` `` instead of `` ``` ``), collapsed doubled `---` separators.

### Scaffolding cleanup

Deleted six empty placeholder paths that no code imported and which the docs were drifting around:

- `src/features/auth/` (empty `components/`, `hooks/`, `hoc/`, `providers/`, `store/`, `types/`)
- `src/features/dashboard/` (empty `components/`, `hooks/`, `types/`)
- `src/app/[locale]/auth/login/`
- `src/app/[locale]/dashboard/`
- `src/app/auth/`
- `src/services/api/index.ts` (1 empty line) — `src/services/api/` directory removed with it

Git tracks the file delete; the empty directory removals are intrinsic to those file deletes.

## Test plan

Verified locally before pushing — all green:

- [x] `yarn type-check` — clean
- [x] `yarn check:deprecated` — clean
- [x] `yarn test` — 124/124 passing across 18 files
- [x] `yarn ci:check` — 3 pre-existing warnings in `src/lib/utils/http/client-utils.test.ts` (empty arrow bodies, introduced in commit `39357ff`), unrelated to this PR
- [x] Pre-push hook ran the full suite above and passed
- [x] `grep` for any leftover references to `services/api`, `src/lib/env.ts`, deleted feature dirs — only legitimate hits remain (CHANGELOG entry documenting the removal, `features/README.md` example sketch)