### PR TITLE
chore(deps): bump @reduxjs/toolkit, react-redux, lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "validate": "yarn ci:check && yarn type-check && yarn check:deprecated && yarn test && yarn build"
   },
   "dependencies": {
-    "@reduxjs/toolkit": "^2.11.2",
+    "@reduxjs/toolkit": "^2.12.0",
     "@teispace/next-themes": "^0.4.2",
     "axios": "^1.16.1",
     "next": "^16.2.6",
@@ -52,7 +52,7 @@
     "pino": "^10.3.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-redux": "^9.2.0",
+    "react-redux": "^9.3.0",
     "react-secure-storage": "^1.3.2",
     "redux": "^5.0.1",
     "redux-persist": "^6.0.0",
@@ -79,7 +79,7 @@
     "cz-conventional-changelog": "^3.3.0",
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
-    "lint-staged": "^17.0.4",
+    "lint-staged": "^17.0.5",
     "pino-pretty": "^13.1.3",
     "tailwindcss": "^4.3.0",
     "tsx": "^4.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,9 +1392,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reduxjs/toolkit@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@reduxjs/toolkit@npm:2.11.2"
+"@reduxjs/toolkit@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "@reduxjs/toolkit@npm:2.12.0"
   dependencies:
     "@standard-schema/spec": "npm:^1.0.0"
     "@standard-schema/utils": "npm:^0.3.0"
@@ -1410,7 +1410,7 @@ __metadata:
       optional: true
     react-redux:
       optional: true
-  checksum: 10c0/4d388b96dc4b12a577af23607c252b3647c1b3b5136dbb0212e1dbbef9bb309e93d3ba6a95795ee165e87e4286453025cd67a98b5b3bb6d244b93ea487dd1ac0
+  checksum: 10c0/2b85e31294a7139994fd78b08eb3ce706ce3b03b5081c13403b93ba4883a152d637171e4d9d969766238851f8915b1daa9f36b5a0a458aff0ff7600ee38795c9
   languageName: node
   linkType: hard
 
@@ -4232,9 +4232,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lint-staged@npm:^17.0.4":
-  version: 17.0.4
-  resolution: "lint-staged@npm:17.0.4"
+"lint-staged@npm:^17.0.5":
+  version: 17.0.5
+  resolution: "lint-staged@npm:17.0.5"
   dependencies:
     listr2: "npm:^10.2.1"
     picomatch: "npm:^4.0.4"
@@ -4246,7 +4246,7 @@ __metadata:
       optional: true
   bin:
     lint-staged: bin/lint-staged.js
-  checksum: 10c0/7a1057eb3dff21236e3efcf199241282488d7cb875caabe3d0cd0cc21886b726a8dad65214f9e509b6f722630be6d5b7eace84c016fac35ecb6e2350843c738d
+  checksum: 10c0/6ecf2024744147ea768dbd550c0c47f04b295f07d30e5ecb5e375c18d8fc24d4bfa897042f4aabd7c3510054ad5bbbb51fa36e60e8dca853e31f9876ef9a3726
   languageName: node
   linkType: hard
 
@@ -5085,9 +5085,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-redux@npm:^9.2.0":
-  version: 9.2.0
-  resolution: "react-redux@npm:9.2.0"
+"react-redux@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "react-redux@npm:9.3.0"
   dependencies:
     "@types/use-sync-external-store": "npm:^0.0.6"
     use-sync-external-store: "npm:^1.4.0"
@@ -5100,7 +5100,7 @@ __metadata:
       optional: true
     redux:
       optional: true
-  checksum: 10c0/00d485f9d9219ca1507b4d30dde5f6ff8fb68ba642458f742e0ec83af052f89e65cd668249b99299e1053cc6ad3d2d8ac6cb89e2f70d2ac5585ae0d7fa0ef259
+  checksum: 10c0/b9f4efcfbfbc90cac9d1709ab3affb1e18a9dc9bd3cceda43bd2e1d9d2394ee0c29df36ec2202d52b566db774888b594c8c5aa86b64f27ef34fca607c687c9e3
   languageName: node
   linkType: hard
 
@@ -5802,7 +5802,7 @@ __metadata:
     "@commitlint/cli": "npm:^21.0.1"
     "@commitlint/config-conventional": "npm:^21.0.1"
     "@next/bundle-analyzer": "npm:^16.2.6"
-    "@reduxjs/toolkit": "npm:^2.11.2"
+    "@reduxjs/toolkit": "npm:^2.12.0"
     "@tailwindcss/postcss": "npm:^4.3.0"
     "@teispace/next-themes": "npm:^0.4.2"
     "@testing-library/dom": "npm:^10.4.1"
@@ -5819,14 +5819,14 @@ __metadata:
     cz-conventional-changelog: "npm:^3.3.0"
     husky: "npm:^9.1.7"
     jsdom: "npm:^29.1.1"
-    lint-staged: "npm:^17.0.4"
+    lint-staged: "npm:^17.0.5"
     next: "npm:^16.2.6"
     next-intl: "npm:^4.12.0"
     pino: "npm:^10.3.1"
     pino-pretty: "npm:^13.1.3"
     react: "npm:^19.2.6"
     react-dom: "npm:^19.2.6"
-    react-redux: "npm:^9.2.0"
+    react-redux: "npm:^9.3.0"
     react-secure-storage: "npm:^1.3.2"
     redux: "npm:^5.0.1"
     redux-persist: "npm:^6.0.0"


### PR DESCRIPTION
## Summary

Minor bumps within existing major-version ranges already allowed by `package.json`. No code changes required.

| Package | From | To |
| --- | --- | --- |
| `@reduxjs/toolkit` | `^2.11.2` | `^2.12.0` |
| `react-redux` | `^9.2.0` | `^9.3.0` |
| `lint-staged` | `^17.0.4` | `^17.0.5` |

## Test plan

Pre-push hook ran the full validation suite before this branch was pushed — all green:

- [x] `yarn ci:check` — only pre-existing warnings in `src/lib/utils/http/client-utils.test.ts` (unrelated)
- [x] `yarn type-check` — clean
- [x] `yarn check:deprecated` — clean
- [x] `yarn test` — 124/124 passing across 18 files
- [ ] CI runs the production build on this PR