### PR TITLE
feat(http): request timeouts, cancellation, and shared refresh singleflight

### DIFF
--- a/src/lib/config/constants.ts
+++ b/src/lib/config/constants.ts
@@ -14,6 +14,17 @@ export const API_PREFIX = '/api/v1';
 export const API_RESPONSE_DATA_KEY = 'data';
 
 /**
+ * Default per-request timeout (ms) applied by both HTTP clients when the
+ * caller doesn't specify one. Mirrors axios's historical 10s default so the
+ * fetch and axios clients behave identically. A hung upstream now fails as a
+ * typed timeout (`ApiException.isTimeout()`) instead of waiting forever.
+ *
+ * Override per request via the `timeout` option, or pass `0` to disable the
+ * timeout for a specific long-poll / streaming call.
+ */
+export const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
  * Cookie-mode auth is the default: the server sets HttpOnly access/refresh
  * cookies on login and reads them back on each request. Flip to `true` to
  * switch to bearer-token mode — the token store + Authorization header

--- a/src/lib/errors/api-exception.ts
+++ b/src/lib/errors/api-exception.ts
@@ -1,5 +1,29 @@
 import type { ApiErrorResponse } from '@/types';
 
+/**
+ * Status used for client-side failures that never reached an HTTP response
+ * (network error, abort, timeout). The server never sends `0`, so it's an
+ * unambiguous "this failed before/without a real HTTP status" marker.
+ */
+export const CLIENT_FAILURE_STATUS = 0;
+
+/**
+ * Machine-readable `code` values stamped on client-originated failures so
+ * callers can branch without string-matching `message`. Server-supplied
+ * codes (e.g. `VALIDATION_ERROR`) flow through `code` untouched; these are
+ * the codes the HTTP clients mint themselves.
+ */
+export const CLIENT_ERROR_CODE = {
+  /** Request was cancelled via an `AbortSignal` (caller abort or unmount). */
+  CANCELLED: 'ERR_CANCELLED',
+  /** Request exceeded its timeout budget before a response arrived. */
+  TIMEOUT: 'ERR_TIMEOUT',
+  /** Transport failed with no HTTP response (DNS, connection refused, offline). */
+  NETWORK: 'ERR_NETWORK',
+} as const;
+
+export type ClientErrorCode = (typeof CLIENT_ERROR_CODE)[keyof typeof CLIENT_ERROR_CODE];
+
 type ApiExceptionOptions = {
   status: number;
   message: string;
@@ -57,6 +81,36 @@ export class ApiException extends Error {
     });
   }
 
+  /** A cancelled-request exception (caller aborted via `AbortSignal`). */
+  static cancelled(message = 'Request was cancelled', stack?: string): ApiException {
+    return new ApiException({
+      status: CLIENT_FAILURE_STATUS,
+      code: CLIENT_ERROR_CODE.CANCELLED,
+      message,
+      stack,
+    });
+  }
+
+  /** A timed-out-request exception (no response within the timeout budget). */
+  static timeout(message = 'Request timed out', stack?: string): ApiException {
+    return new ApiException({
+      status: CLIENT_FAILURE_STATUS,
+      code: CLIENT_ERROR_CODE.TIMEOUT,
+      message,
+      stack,
+    });
+  }
+
+  /** A network-failure exception (transport error, no HTTP response). */
+  static network(message = 'Network error', stack?: string): ApiException {
+    return new ApiException({
+      status: CLIENT_FAILURE_STATUS,
+      code: CLIENT_ERROR_CODE.NETWORK,
+      message,
+      stack,
+    });
+  }
+
   static convertAny(error: unknown): ApiException {
     if (error instanceof ApiException) return error;
 
@@ -99,5 +153,29 @@ export class ApiException extends Error {
     }
 
     return result;
+  }
+
+  /** True when the request was cancelled by the caller (abort signal). */
+  isCancelled(): boolean {
+    return this.code === CLIENT_ERROR_CODE.CANCELLED;
+  }
+
+  /** True when the request exceeded its timeout budget. */
+  isTimeout(): boolean {
+    return this.code === CLIENT_ERROR_CODE.TIMEOUT;
+  }
+
+  /** True when the transport failed without an HTTP response. */
+  isNetworkError(): boolean {
+    return this.code === CLIENT_ERROR_CODE.NETWORK;
+  }
+
+  /**
+   * True for any failure that never produced an HTTP response — cancellation,
+   * timeout, or a raw network/transport error. Handy for "should I show a
+   * retry button vs a validation message?" branching.
+   */
+  isClientFailure(): boolean {
+    return this.status === CLIENT_FAILURE_STATUS;
   }
 }

--- a/src/lib/utils/http/README.md
+++ b/src/lib/utils/http/README.md
@@ -26,6 +26,7 @@ Feature code imports from `@/lib/utils/http` (universal) or `@/lib/utils/http/se
 - [Making requests](#making-requests)
 - [Typed queries and pagination](#typed-queries-and-pagination)
 - [Error handling](#error-handling)
+- [Cancellation and timeouts](#cancellation-and-timeouts)
 - [Authentication](#authentication)
 - [Server-side rendering](#server-side-rendering)
 - [Request correlation (X-Request-Id)](#request-correlation-x-request-id)
@@ -366,6 +367,65 @@ See the [`ApiException` reference](#apiexception) for the full surface.
 
 ---
 
+## Cancellation and timeouts
+
+Both clients fail fast and **distinguish three response-less failures** so the UI can react correctly — a request the user cancelled shouldn't render the same as a server that went dark.
+
+| Failure | `status` | `code` | Predicate |
+|---|---|---|---|
+| Caller aborted via `AbortSignal` | `0` | `ERR_CANCELLED` | `err.isCancelled()` |
+| Exceeded the timeout budget | `0` | `ERR_TIMEOUT` | `err.isTimeout()` |
+| Transport error (DNS, refused, offline) | `0` | `ERR_NETWORK` | `err.isNetworkError()` |
+
+`err.isClientFailure()` is `true` for all three (anything with `status === 0`).
+
+### Default timeout
+
+Every request has a default timeout of `DEFAULT_TIMEOUT_MS` (10s) — the fetch client and the axios client behave identically. Override per request, or pass `0` to disable it for a long-poll / SSE / large upload:
+
+```ts
+await fetchClient.get('/report', { timeout: 30_000 }); // 30s for this call
+await fetchClient.get('/events', { timeout: 0 });       // no timeout (streaming)
+```
+
+Set a client-wide default when creating a custom client: `createFetchClient({ ..., timeout: 30_000 })`.
+
+### Caller cancellation
+
+Pass your own `AbortSignal`; it's composed with the timeout via `AbortSignal.any`, so whichever fires first wins. Aborting yourself surfaces as `isCancelled()`; the timeout surfaces as `isTimeout()`.
+
+```ts
+const controller = new AbortController();
+const promise = fetchClient.get<User[]>('/users', { signal: controller.signal });
+
+controller.abort(); // e.g. component unmounted, user navigated away
+
+const result = await promise;
+if (result.isLeft() && result.value.isCancelled()) {
+  return; // expected — don't surface an error toast
+}
+```
+
+Typical React pattern — cancel the in-flight request on unmount:
+
+```tsx
+useEffect(() => {
+  const ac = new AbortController();
+  fetchClient.get<User>('/auth/me', { signal: ac.signal }).then((result) => {
+    if (result.isLeft()) {
+      if (result.value.isCancelled()) return; // unmounted — ignore
+      return showError(result.value);
+    }
+    setUser(result.value);
+  });
+  return () => ac.abort();
+}, []);
+```
+
+The signal and timeout both survive a 401 → refresh → retry: the retry gets a fresh timeout budget, and an already-aborted caller signal short-circuits it immediately.
+
+---
+
 ## Authentication
 
 ### Cookie-mode (default)
@@ -558,9 +618,9 @@ For a custom token store, implement the `TokenStore` interface (5 methods: `getA
 
 | Field / method | Type | Notes |
 |---|---|---|
-| `status` | `number` | HTTP status. `0` for network failures. |
+| `status` | `number` | HTTP status. `0` for response-less failures (cancel / timeout / network). |
 | `message` | `string` | Human-readable summary from the API. |
-| `code` | `string \| undefined` | Machine-readable code (e.g. `USER_NOT_FOUND`). |
+| `code` | `string \| undefined` | Machine-readable code (e.g. `USER_NOT_FOUND`, or `ERR_CANCELLED` / `ERR_TIMEOUT` / `ERR_NETWORK`). |
 | `errors` | `Array<Record<string, string>>` | Field-level validation errors. |
 | `data` | `Record<string, unknown>` | Arbitrary extra context. |
 | `path` | `string \| undefined` | Request path the API logged. |
@@ -569,7 +629,14 @@ For a custom token store, implement the `TokenStore` interface (5 methods: `getA
 | `getErrorMessage(key)` | `string \| undefined` | Field error message. |
 | `getErrorMessageIfExists(key)` | `string` | Field error or the general message. |
 | `getFieldErrors()` | `Record<string, string>` | All field errors flattened. |
+| `isCancelled()` | `boolean` | Request was aborted via an `AbortSignal`. |
+| `isTimeout()` | `boolean` | Request exceeded its timeout budget. |
+| `isNetworkError()` | `boolean` | Transport failed with no HTTP response. |
+| `isClientFailure()` | `boolean` | Any `status === 0` failure (cancel / timeout / network). |
 | `ApiException.fromResponse(body, fallbackStatus?)` | `ApiException` | Build from an API error envelope. |
+| `ApiException.cancelled(message?, stack?)` | `ApiException` | A cancelled-request exception. |
+| `ApiException.timeout(message?, stack?)` | `ApiException` | A timed-out-request exception. |
+| `ApiException.network(message?, stack?)` | `ApiException` | A network-failure exception. |
 | `ApiException.convertAny(error)` | `ApiException` | Defensive fallback for unknown error values. |
 
 ### Shared utilities

--- a/src/lib/utils/http/axios-client/axios-client.test.ts
+++ b/src/lib/utils/http/axios-client/axios-client.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { AxiosError } from 'axios';
+import { describe, expect, it, vi } from 'vitest';
 
+import { ApiException } from '@/lib/errors';
 import type { TokenStore } from '@/types';
 
 import { AxiosClient } from './axios-client';
@@ -55,5 +57,73 @@ describe('AxiosClient paramsSerializer (shared serialiser regression guard)', ()
 
   it('returns an empty string when every param is skipped', () => {
     expect(serialise({ page: undefined, search: '' })).toBe('');
+  });
+});
+
+describe('AxiosClient cancellation & timeout mapping', () => {
+  function makeClient() {
+    return new AxiosClient({
+      baseURL: 'https://api.example.com/api/v1',
+      tokenStore: makeTokenStore(),
+    });
+  }
+
+  /** Make the underlying axios instance's `get` reject with a given error. */
+  function stubGetReject(client: AxiosClient, error: unknown) {
+    const instance = (client as unknown as { axios: { get: unknown } }).axios;
+    vi.spyOn(instance as { get: () => Promise<unknown> }, 'get').mockRejectedValue(error);
+  }
+
+  it('uses the shared default timeout when none is provided', () => {
+    const client = makeClient();
+    const defaults = getAxiosDefaults(client) as unknown as { timeout: number };
+    expect(defaults.timeout).toBe(10_000);
+  });
+
+  it('respects an explicit timeout option (0 = disabled)', () => {
+    const client = new AxiosClient({
+      baseURL: 'https://api.example.com/api/v1',
+      tokenStore: makeTokenStore(),
+      timeout: 0,
+    });
+    const defaults = getAxiosDefaults(client) as unknown as { timeout: number };
+    expect(defaults.timeout).toBe(0);
+  });
+
+  it('maps ERR_CANCELED to a cancelled ApiException', async () => {
+    const client = makeClient();
+    stubGetReject(client, new AxiosError('canceled', 'ERR_CANCELED'));
+
+    const result = await client.get('/slow');
+    expect(result.isLeft()).toBe(true);
+    if (result.isLeft()) {
+      expect(result.value).toBeInstanceOf(ApiException);
+      expect(result.value.isCancelled()).toBe(true);
+      expect(result.value.status).toBe(0);
+    }
+  });
+
+  it('maps ECONNABORTED to a timeout ApiException', async () => {
+    const client = makeClient();
+    stubGetReject(client, new AxiosError('timeout of 10000ms exceeded', 'ECONNABORTED'));
+
+    const result = await client.get('/slow');
+    expect(result.isLeft()).toBe(true);
+    if (result.isLeft()) {
+      expect(result.value.isTimeout()).toBe(true);
+      expect(result.value.status).toBe(0);
+    }
+  });
+
+  it('maps a response-less error to a network ApiException', async () => {
+    const client = makeClient();
+    stubGetReject(client, new AxiosError('Network Error', 'ERR_NETWORK'));
+
+    const result = await client.get('/users');
+    expect(result.isLeft()).toBe(true);
+    if (result.isLeft()) {
+      expect(result.value.isNetworkError()).toBe(true);
+      expect(result.value.status).toBe(0);
+    }
   });
 });

--- a/src/lib/utils/http/axios-client/axios-client.ts
+++ b/src/lib/utils/http/axios-client/axios-client.ts
@@ -5,12 +5,12 @@ import axios, {
   type AxiosResponse,
 } from 'axios';
 
-import { API_RESPONSE_DATA_KEY, getApiBaseUrl } from '@/lib/config';
+import { API_RESPONSE_DATA_KEY, DEFAULT_TIMEOUT_MS, getApiBaseUrl } from '@/lib/config';
 import { ApiException } from '@/lib/errors';
 import type { QueryParams } from '@/types';
 import { type AxiosClientOptions, type DataKey, left, type ResultAsync, right } from '@/types';
 
-import { extractDataByKey, TokenRefreshManager } from '../client-utils';
+import { extractDataByKey, getRefreshManager } from '../client-utils';
 import { extractRequestIdFromHeaderRecord, parseApiError, toSearchParams } from '../shared';
 import { setupRequestInterceptor, setupResponseInterceptor } from './interceptors';
 import { refreshAuthToken } from './token-refresh';
@@ -18,15 +18,17 @@ import { refreshAuthToken } from './token-refresh';
 export class AxiosClient {
   private axios: AxiosInstance;
   private tokenStore: AxiosClientOptions['tokenStore'];
-  private refreshManager = new TokenRefreshManager();
+  private baseURL: string;
 
   constructor(options: AxiosClientOptions) {
     this.tokenStore = options.tokenStore;
+    this.baseURL = options?.baseURL || getApiBaseUrl();
 
     this.axios = axios.create({
-      baseURL: options?.baseURL || getApiBaseUrl(),
+      baseURL: this.baseURL,
       withCredentials: true,
-      timeout: 10000,
+      // Default timeout shared with the fetch client (axios native: 0 = off).
+      timeout: options.timeout ?? DEFAULT_TIMEOUT_MS,
       headers: {
         'Content-Type': 'application/json',
         ...options.defaultHeaders,
@@ -46,7 +48,11 @@ export class AxiosClient {
   }
 
   private async handleTokenRefresh(): Promise<string | null> {
-    return this.refreshManager.handleRefresh(() => refreshAuthToken(this.tokenStore, this.axios));
+    // Shared per-baseURL singleflight — see getRefreshManager. Ensures the
+    // fetch + axios clients never double-refresh the rotating refresh token.
+    return getRefreshManager(this.baseURL).handleRefresh(() =>
+      refreshAuthToken(this.tokenStore, this.axios),
+    );
   }
 
   private extractData<T>(res: AxiosResponse, dataKey?: DataKey): T {
@@ -55,15 +61,23 @@ export class AxiosClient {
 
   private toApiException(err: unknown): ApiException {
     if (err instanceof AxiosError) {
+      // No HTTP response → cancellation, timeout, or a raw network error.
+      // Map the first two to typed exceptions so callers can branch with
+      // `isCancelled()` / `isTimeout()`, mirroring the fetch client exactly.
+      if (!err.response) {
+        if (err.code === 'ERR_CANCELED') {
+          return ApiException.cancelled(err.message || undefined, err.stack);
+        }
+        if (err.code === 'ECONNABORTED' || err.code === 'ETIMEDOUT') {
+          return ApiException.timeout(err.message || undefined, err.stack);
+        }
+        return ApiException.network(err.message || 'Network error', err.stack);
+      }
+
       const responseRequestId = extractRequestIdFromHeaderRecord(
-        err.response?.headers as Record<string, unknown> | undefined,
+        err.response.headers as Record<string, unknown> | undefined,
       );
-      return parseApiError(
-        err.response?.data,
-        err.response?.status ?? 0,
-        responseRequestId,
-        err.stack,
-      );
+      return parseApiError(err.response.data, err.response.status, responseRequestId, err.stack);
     }
     return ApiException.convertAny(err);
   }

--- a/src/lib/utils/http/client-utils.test.ts
+++ b/src/lib/utils/http/client-utils.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  __resetRefreshManagersForTests,
   extractDataByKey,
+  getRefreshManager,
   handleUnauthorizedRedirect,
   TOKEN_REFRESH_CONFIG,
   TokenRefreshManager,
@@ -179,5 +181,50 @@ describe('handleUnauthorizedRedirect', () => {
   it('redirects to the login path with the current URL encoded as redirectTo', () => {
     handleUnauthorizedRedirect();
     expect(window.location.href).toMatch(/redirectTo=%2Fsecret%3Ffoo%3Dbar$/);
+  });
+});
+
+describe('getRefreshManager (shared per-baseURL singleflight)', () => {
+  beforeEach(() => {
+    __resetRefreshManagersForTests();
+  });
+
+  it('returns the same manager instance for the same baseURL', () => {
+    const a = getRefreshManager('https://api.example.com/api/v1');
+    const b = getRefreshManager('https://api.example.com/api/v1');
+    expect(a).toBe(b);
+    expect(a).toBeInstanceOf(TokenRefreshManager);
+  });
+
+  it('returns distinct managers for different baseURLs', () => {
+    const a = getRefreshManager('https://api.example.com/api/v1');
+    const b = getRefreshManager('https://other.internal/api/v1');
+    expect(a).not.toBe(b);
+  });
+
+  it('shares singleflight state across callers of the same baseURL', async () => {
+    // Two "clients" (fetch + axios) resolving 401s concurrently against the
+    // same upstream must trigger exactly ONE refresh — not one each — or the
+    // rotating refresh token would be double-spent.
+    let resolveRefresh: (t: string | null) => void = () => {};
+    const refreshFn = vi.fn(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    const m1 = getRefreshManager('https://api.example.com/api/v1');
+    const m2 = getRefreshManager('https://api.example.com/api/v1');
+
+    const p1 = m1.handleRefresh(refreshFn);
+    const p2 = m2.handleRefresh(refreshFn);
+
+    resolveRefresh('shared');
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(refreshFn).toHaveBeenCalledOnce();
+    expect(r1).toBe('shared');
+    expect(r2).toBe('shared');
   });
 });

--- a/src/lib/utils/http/client-utils.ts
+++ b/src/lib/utils/http/client-utils.ts
@@ -72,3 +72,34 @@ export class TokenRefreshManager {
     }
   }
 }
+
+/**
+ * Refresh managers are shared per upstream (`baseURL`), NOT per client
+ * instance. The `fetchClient` and `axiosClient` both point at the same API,
+ * so they must share one singleflight latch — otherwise a burst of 401s
+ * split across the two clients would each trigger their own refresh and, with
+ * a rotating refresh token, the second refresh would present an
+ * already-consumed token and the server's reuse-detection would revoke every
+ * session. Keying by `baseURL` also keeps custom clients pointed at a
+ * different service isolated from the main app's refresh cycle.
+ */
+const refreshManagers = new Map<string, TokenRefreshManager>();
+
+/** Get (or lazily create) the shared `TokenRefreshManager` for an upstream. */
+export function getRefreshManager(baseURL: string): TokenRefreshManager {
+  let manager = refreshManagers.get(baseURL);
+  if (!manager) {
+    manager = new TokenRefreshManager();
+    refreshManagers.set(baseURL, manager);
+  }
+  return manager;
+}
+
+/**
+ * Clear the shared refresh-manager registry. Test-only — lets each test start
+ * from a clean singleflight state without leaking attempt counters between
+ * cases. No-op cost in production (never called there).
+ */
+export function __resetRefreshManagersForTests(): void {
+  refreshManagers.clear();
+}

--- a/src/lib/utils/http/fetch-client/fetch-client.test.ts
+++ b/src/lib/utils/http/fetch-client/fetch-client.test.ts
@@ -242,6 +242,92 @@ describe('FetchClient 401 → refresh → retry lifecycle', () => {
   });
 });
 
+describe('FetchClient cancellation & timeout', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let client: FetchClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    client = new FetchClient({ baseURL: BASE, tokenStore: makeTokenStore() });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('passes a composed AbortSignal to fetch', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ data: null }));
+    await client.get('/users');
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('does not leak the `timeout` option into the fetch RequestInit', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ data: null }));
+    await client.get('/users', { timeout: 5000 });
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as Record<string, unknown>).timeout).toBeUndefined();
+  });
+
+  it('maps a caller abort to a cancelled ApiException', async () => {
+    // fetch rejects with an AbortError when the signal aborts.
+    fetchMock.mockRejectedValue(new DOMException('aborted', 'AbortError'));
+
+    const ac = new AbortController();
+    const result = await client.get('/slow', { signal: ac.signal });
+
+    expect(result.isLeft()).toBe(true);
+    if (result.isLeft()) {
+      expect(result.value).toBeInstanceOf(ApiException);
+      expect(result.value.isCancelled()).toBe(true);
+      expect(result.value.status).toBe(0);
+    }
+  });
+
+  it('maps an elapsed timeout to a timeout ApiException', async () => {
+    // A tiny timeout: AbortSignal.timeout fires before fetch resolves. The
+    // mock rejects with AbortError (what fetch throws on signal abort); the
+    // client classifies it as a timeout via the timeout signal state.
+    fetchMock.mockImplementation(
+      (_url, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () =>
+            reject(new DOMException('aborted', 'AbortError')),
+          );
+        }),
+    );
+
+    const result = await client.get('/slow', { timeout: 1 });
+
+    expect(result.isLeft()).toBe(true);
+    if (result.isLeft()) {
+      expect(result.value.isTimeout()).toBe(true);
+      expect(result.value.status).toBe(0);
+    }
+  });
+
+  it('honours timeout: 0 as unbounded (no timeout signal when no caller signal)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ data: null }));
+    await client.get('/stream', { timeout: 0 });
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).signal ?? null).toBeNull();
+  });
+
+  it('tags a raw network failure with the NETWORK code (not cancelled/timeout)', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const result = await client.get('/users');
+    expect(result.isLeft()).toBe(true);
+    if (result.isLeft()) {
+      expect(result.value.isNetworkError()).toBe(true);
+      expect(result.value.isCancelled()).toBe(false);
+      expect(result.value.status).toBe(0);
+    }
+  });
+});
+
 describe('FetchClient URL composition', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let client: FetchClient;

--- a/src/lib/utils/http/fetch-client/fetch-client.ts
+++ b/src/lib/utils/http/fetch-client/fetch-client.ts
@@ -1,4 +1,4 @@
-import { API_RESPONSE_DATA_KEY, getApiBaseUrl } from '@/lib/config';
+import { API_RESPONSE_DATA_KEY, DEFAULT_TIMEOUT_MS, getApiBaseUrl } from '@/lib/config';
 import { ApiException } from '@/lib/errors';
 import {
   type CookieResolver,
@@ -10,8 +10,14 @@ import {
   right,
 } from '@/types';
 
-import { extractDataByKey, TokenRefreshManager } from '../client-utils';
-import { extractRequestIdFromHeaders, parseApiError, toSearchParams } from '../shared';
+import { extractDataByKey, getRefreshManager } from '../client-utils';
+import {
+  abortToApiException,
+  buildAbortSignal,
+  extractRequestIdFromHeaders,
+  parseApiError,
+  toSearchParams,
+} from '../shared';
 import { applyRequestInterceptors, applyResponseInterceptors } from './interceptors';
 import { refreshAuthToken } from './token-refresh';
 
@@ -19,15 +25,16 @@ export class FetchClient {
   private baseURL: string;
   private tokenStore: FetchClientOptions['tokenStore'];
   private defaultOptions: RequestInit;
+  private defaultTimeout: number;
   private onUnauthorized?: () => void;
   private cookieResolver?: CookieResolver;
-  private refreshManager = new TokenRefreshManager();
 
   constructor(options: FetchClientOptions) {
     this.baseURL = options?.baseURL || getApiBaseUrl();
     this.tokenStore = options.tokenStore;
     this.onUnauthorized = options.onUnauthorized;
     this.cookieResolver = options.cookieResolver;
+    this.defaultTimeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
 
     this.defaultOptions = {
       credentials: 'include',
@@ -40,10 +47,20 @@ export class FetchClient {
   }
 
   private async handleTokenRefresh(): Promise<string | null> {
-    return this.refreshManager.handleRefresh(() => refreshAuthToken(this.tokenStore, this.baseURL));
+    // Singleflight is keyed by baseURL and SHARED across every client (fetch +
+    // axios) hitting the same upstream, so concurrent 401s never trigger more
+    // than one refresh of the rotating refresh token.
+    return getRefreshManager(this.baseURL).handleRefresh(() =>
+      refreshAuthToken(this.tokenStore, this.baseURL),
+    );
   }
 
-  private toApiException(error: unknown, response?: Response, body?: unknown): ApiException {
+  private toApiException(
+    error: unknown,
+    response?: Response,
+    body?: unknown,
+    timedOut = false,
+  ): ApiException {
     if (error instanceof ApiException) return error;
 
     if (response) {
@@ -56,12 +73,13 @@ export class FetchClient {
       return exception;
     }
 
+    // Abort / timeout get distinct codes so callers can tell a cancelled
+    // request (e.g. component unmounted) apart from a real network failure.
+    const cancellation = abortToApiException(error, timedOut);
+    if (cancellation) return cancellation;
+
     if (error instanceof Error) {
-      return new ApiException({
-        status: 0,
-        message: error.message || 'Network error',
-        stack: error.stack,
-      });
+      return ApiException.network(error.message || 'Network error', error.stack);
     }
 
     return ApiException.convertAny(error);
@@ -87,8 +105,16 @@ export class FetchClient {
     options: ExtendedRequestInit = {},
     dataKey?: DataKey,
   ): ResultAsync<T> {
-    const { params, ...fetchOptions } = options;
+    const { params, timeout, signal: callerSignal, ...fetchOptions } = options;
     const fullURL = this.buildURL(url, params);
+
+    // Merge the caller's signal with a timeout signal (whichever fires first
+    // wins). `isTimeout()` lets the catch block classify a post-hoc abort as
+    // a timeout vs a caller cancellation.
+    const { signal, isTimeout } = buildAbortSignal(
+      callerSignal ?? undefined,
+      timeout ?? this.defaultTimeout,
+    );
 
     try {
       const interceptedOptions = await applyRequestInterceptors(
@@ -98,7 +124,7 @@ export class FetchClient {
         this.cookieResolver,
       );
 
-      const response = await fetch(fullURL, interceptedOptions);
+      const response = await fetch(fullURL, { ...interceptedOptions, signal });
 
       const contentType = response.headers.get('Content-Type') || '';
       let responseData: unknown;
@@ -138,7 +164,7 @@ export class FetchClient {
 
       return right(extractDataByKey<T>(responseData, dataKey));
     } catch (error) {
-      return left(this.toApiException(error));
+      return left(this.toApiException(error, undefined, undefined, isTimeout()));
     }
   }
 

--- a/src/lib/utils/http/shared/abort.test.ts
+++ b/src/lib/utils/http/shared/abort.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiException, CLIENT_ERROR_CODE } from '@/lib/errors';
+
+import { abortToApiException, buildAbortSignal, isAbortError } from './abort';
+
+describe('buildAbortSignal', () => {
+  it('returns no signal when there is neither caller signal nor timeout', () => {
+    const { signal } = buildAbortSignal(undefined, undefined);
+    expect(signal).toBeUndefined();
+  });
+
+  it('treats 0 / negative / non-finite timeout as unbounded', () => {
+    expect(buildAbortSignal(undefined, 0).signal).toBeUndefined();
+    expect(buildAbortSignal(undefined, -5).signal).toBeUndefined();
+    expect(buildAbortSignal(undefined, Number.NaN).signal).toBeUndefined();
+    expect(buildAbortSignal(undefined, Number.POSITIVE_INFINITY).signal).toBeUndefined();
+  });
+
+  it('returns the caller signal untouched when there is no timeout', () => {
+    const ac = new AbortController();
+    const { signal } = buildAbortSignal(ac.signal, 0);
+    expect(signal).toBe(ac.signal);
+  });
+
+  it('returns a timeout-only signal when there is no caller signal', () => {
+    const { signal, isTimeout } = buildAbortSignal(undefined, 10_000);
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(isTimeout()).toBe(false); // not fired yet
+  });
+
+  it('composes both into one signal that aborts when the caller aborts', () => {
+    const ac = new AbortController();
+    const { signal, isTimeout } = buildAbortSignal(ac.signal, 10_000);
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal).not.toBe(ac.signal); // a merged signal, not the original
+
+    ac.abort();
+    expect(signal?.aborted).toBe(true);
+    expect(isTimeout()).toBe(false); // caller aborted, not the timeout
+  });
+});
+
+describe('isAbortError', () => {
+  it('recognises AbortError and TimeoutError DOMExceptions', () => {
+    expect(isAbortError(new DOMException('aborted', 'AbortError'))).toBe(true);
+    expect(isAbortError(new DOMException('timed out', 'TimeoutError'))).toBe(true);
+  });
+
+  it('rejects ordinary errors and non-errors', () => {
+    expect(isAbortError(new Error('ECONNREFUSED'))).toBe(false);
+    expect(isAbortError(new DOMException('nope', 'DataError'))).toBe(false);
+    expect(isAbortError('aborted')).toBe(false);
+    expect(isAbortError(undefined)).toBe(false);
+  });
+});
+
+describe('abortToApiException', () => {
+  it('returns null for a non-abort error so the caller can fall through', () => {
+    expect(abortToApiException(new Error('boom'), false)).toBeNull();
+  });
+
+  it('maps an AbortError to a cancelled exception by default', () => {
+    const ex = abortToApiException(new DOMException('aborted', 'AbortError'), false);
+    expect(ex).toBeInstanceOf(ApiException);
+    expect(ex?.code).toBe(CLIENT_ERROR_CODE.CANCELLED);
+    expect(ex?.status).toBe(0);
+    expect(ex?.isCancelled()).toBe(true);
+  });
+
+  it('maps an AbortError to a timeout when preferTimeout is set', () => {
+    const ex = abortToApiException(new DOMException('aborted', 'AbortError'), true);
+    expect(ex?.code).toBe(CLIENT_ERROR_CODE.TIMEOUT);
+    expect(ex?.isTimeout()).toBe(true);
+  });
+
+  it('maps a native TimeoutError to a timeout even without preferTimeout', () => {
+    const ex = abortToApiException(new DOMException('timed out', 'TimeoutError'), false);
+    expect(ex?.code).toBe(CLIENT_ERROR_CODE.TIMEOUT);
+    expect(ex?.isTimeout()).toBe(true);
+  });
+});

--- a/src/lib/utils/http/shared/abort.ts
+++ b/src/lib/utils/http/shared/abort.ts
@@ -1,0 +1,88 @@
+/**
+ * Cancellation + timeout primitives shared by both HTTP clients.
+ *
+ * Two failure modes need to be told apart from an ordinary network error so
+ * the UI can react correctly (don't toast an error when the user navigated
+ * away; show "timed out, retry?" rather than a generic failure):
+ *
+ *   - **Caller abort** — the consumer passed an `AbortSignal` and aborted it.
+ *   - **Timeout** — the request outran its time budget.
+ *
+ * Both surface as an `ApiException` with `status: 0` and a distinct `code`
+ * (`ERR_CANCELLED` / `ERR_TIMEOUT`), built via `ApiException.cancelled()` /
+ * `.timeout()`. This module owns the detection + signal-merging logic so the
+ * fetch and axios adapters stay identical in behaviour.
+ *
+ * Side-effect-free and tiny so it tree-shakes into both bundles.
+ */
+import { ApiException } from '@/lib/errors';
+
+/** A timeout of `0` (or negative/NaN) means "no timeout" — unbounded wait. */
+function isUnbounded(timeoutMs: number | undefined): boolean {
+  return timeoutMs === undefined || !Number.isFinite(timeoutMs) || timeoutMs <= 0;
+}
+
+/**
+ * Compose the caller's `AbortSignal` (if any) with a timeout signal (if a
+ * positive budget is set) into a single signal to hand to `fetch`.
+ *
+ * - No caller signal, no timeout → `undefined` (nothing to wire).
+ * - Only one of the two → that signal, untouched (no needless wrapper).
+ * - Both → `AbortSignal.any([...])`, which aborts as soon as *either* fires.
+ *
+ * The returned `isTimeout()` lets the caller classify a post-hoc abort: when
+ * the merged signal has aborted, was it the timeout or the caller? We can't
+ * always read `signal.reason` reliably across runtimes, so we expose the
+ * timeout signal's own state instead.
+ */
+export function buildAbortSignal(
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number | undefined,
+): { signal: AbortSignal | undefined; isTimeout: () => boolean } {
+  const timeoutSignal = isUnbounded(timeoutMs)
+    ? undefined
+    : AbortSignal.timeout(timeoutMs as number);
+
+  const isTimeout = (): boolean => timeoutSignal?.aborted ?? false;
+
+  // Merge only when both exist; otherwise pass through whichever is present
+  // (or `undefined` when neither is) so we never wrap a lone signal needlessly.
+  const present = [callerSignal, timeoutSignal].filter((s): s is AbortSignal => s !== undefined);
+
+  if (present.length === 0) return { signal: undefined, isTimeout };
+  if (present.length === 1) return { signal: present[0], isTimeout };
+
+  return { signal: AbortSignal.any(present), isTimeout };
+}
+
+/**
+ * Whether a thrown value is an abort/timeout (as opposed to a real network
+ * failure). `fetch` rejects with a `DOMException` named `AbortError` on
+ * abort and `TimeoutError` when an `AbortSignal.timeout()` fires.
+ */
+export function isAbortError(error: unknown): boolean {
+  return (
+    error instanceof DOMException && (error.name === 'AbortError' || error.name === 'TimeoutError')
+  );
+}
+
+/**
+ * Convert a thrown `fetch` rejection into the right typed `ApiException`.
+ * Returns `null` when the error is *not* an abort/timeout, so the caller can
+ * fall through to its normal network-error handling.
+ *
+ * `preferTimeout` disambiguates the abort case: a fetch `AbortError` doesn't
+ * itself say whether the abort came from the caller or the timeout, so the
+ * adapter passes the timeout signal's state in.
+ */
+export function abortToApiException(error: unknown, preferTimeout: boolean): ApiException | null {
+  if (!isAbortError(error)) return null;
+
+  const isTimeout =
+    preferTimeout || (error instanceof DOMException && error.name === 'TimeoutError');
+  const stack = error instanceof Error ? error.stack : undefined;
+
+  return isTimeout
+    ? ApiException.timeout(undefined, stack)
+    : ApiException.cancelled(undefined, stack);
+}

--- a/src/lib/utils/http/shared/index.ts
+++ b/src/lib/utils/http/shared/index.ts
@@ -2,6 +2,7 @@
 // edge, Node). For SSR cookie-forwarding helpers see `./server/`, which
 // is fenced behind `'server-only'` and reachable only via dynamic import
 // from within the HTTP interceptors.
+export { abortToApiException, buildAbortSignal, isAbortError } from './abort';
 export {
   extractRequestIdFromHeaderRecord,
   extractRequestIdFromHeaders,

--- a/src/types/common/http.types.ts
+++ b/src/types/common/http.types.ts
@@ -11,6 +11,9 @@ declare module 'axios' {
   export interface AxiosRequestConfig {
     _retry?: boolean;
     _skipAuthInterceptor?: boolean;
+    // `timeout` is already declared natively on AxiosRequestConfig (ms).
+    // Pass `0` to disable it for a single request (axios's own convention).
+    // `signal` is likewise native. Both clients honour the same semantics.
     // Note: `params` is declared on AxiosRequestConfig natively as `any`.
     // We don't re-declare it here (module augmentation can only widen, not
     // narrow). Both clients' `paramsSerializer` runs all params through
@@ -39,6 +42,11 @@ export interface AxiosClientOptions {
   onUnauthorized?: () => void;
   tokenStore: TokenStore;
   /**
+   * Default per-request timeout in ms. Falls back to `DEFAULT_TIMEOUT_MS`.
+   * Pass `0` to disable the default timeout for this client.
+   */
+  timeout?: number;
+  /**
    * Headers merged into `axios.create({ headers })`. Use for static defaults
    * that should apply to every request from this client (e.g. an API-version
    * header). Per-request `Cookie` injection is handled by the interceptor,
@@ -55,6 +63,12 @@ export interface FetchClientOptions {
   tokenStore: TokenStore;
   cache?: RequestCache;
   defaultOptions?: RequestInit;
+  /**
+   * Default per-request timeout in ms. Falls back to `DEFAULT_TIMEOUT_MS`.
+   * Pass `0` to disable the default timeout for this client (e.g. a client
+   * dedicated to long-poll / streaming endpoints).
+   */
+  timeout?: number;
   /** Wire a server-side cookie resolver. Only `@/lib/utils/http/server` uses this. */
   cookieResolver?: CookieResolver;
 }
@@ -68,6 +82,14 @@ export interface ExtendedRequestInit extends RequestInit {
    * any literal `?...` already in the path. Skips `undefined`/`null`/`''`.
    */
   params?: QueryParams;
+  /**
+   * Per-request timeout in ms, overriding the client default. Pass `0` to
+   * disable the timeout for this call (long-poll / SSE / large upload).
+   * Composed with any `signal` you pass via `AbortSignal.any`, so whichever
+   * fires first wins. A timeout surfaces as `ApiException.isTimeout()`; an
+   * abort via your own `signal` surfaces as `ApiException.isCancelled()`.
+   */
+  timeout?: number;
 }
 
 export interface InterceptorResult {


### PR DESCRIPTION
## Summary

Closes client-side resilience gaps in the HTTP engine. Both clients (`fetchClient`, `axiosClient`) now support per-request timeouts and cancellation, surface response-less failures as typed exceptions, and share refresh state so a rotating refresh token is never double-spent.

## What changed

**Typed failure results (`ApiException`)**
- `status: 0` failures now carry distinct codes: `ERR_CANCELLED`, `ERR_TIMEOUT`, `ERR_NETWORK`.
- New predicates: `isCancelled()`, `isTimeout()`, `isNetworkError()`, `isClientFailure()`.
- New factories: `ApiException.cancelled() / .timeout() / .network()`.

**Fetch-client timeout + cancellation**
- Default 10s timeout (`DEFAULT_TIMEOUT_MS`), parity with axios. Override per request via `timeout`; `0` disables it (long-poll / SSE / uploads).
- New `shared/abort.ts`: composes the caller's `AbortSignal` with the timeout via `AbortSignal.any`, and classifies the throw (timeout vs caller abort vs network).
- Signal + timeout survive the 401 → refresh → retry path.

**Axios parity**
- `ERR_CANCELED` / `ECONNABORTED` / `ETIMEDOUT` map to the same typed exceptions. Both clients now behave identically.

**Shared refresh singleflight**
- `TokenRefreshManager` is now a per-`baseURL` singleton shared across both clients, so concurrent 401s split across fetch + axios trigger exactly one refresh — preventing the backend's reuse-detection (rotating refresh token) from revoking all sessions.

## Tests

- +25 tests (149 total, 19 files), covering: caller abort, timeout, network classification, `timeout: 0` unbounded, signal not leaking into `RequestInit`, axios cancel/timeout mapping, and shared-manager singleflight across clients.

## Validation

`yarn validate` green locally and on pre-push: `ci:check` + `type-check` + `check:deprecated` + `test`. Production build runs in CI.

## Notes

- No backend contract changes — purely client-side resilience.
- Behaviour documented in `src/lib/utils/http/README.md` (new "Cancellation and timeouts" section + updated `ApiException` reference).