### PR TITLE
refactor(env): read NODE_ENV through the typed env

### DIFF
--- a/src/lib/config/constants.ts
+++ b/src/lib/config/constants.ts
@@ -1,4 +1,5 @@
 import { Environment } from '../enums';
+import { env } from '../env';
 
 /**
  * URI version prefix mounted by the API (`/api/v{n}`).
@@ -32,6 +33,8 @@ export const DEFAULT_TIMEOUT_MS = 10_000;
  */
 export const SAVE_AUTH_TOKENS = false;
 
-export const isProduction = process.env.NODE_ENV === Environment.PRODUCTION;
-export const isDevelopment = process.env.NODE_ENV === Environment.DEVELOPMENT;
-export const isTest = process.env.NODE_ENV === Environment.TEST;
+// Read NODE_ENV through the validated, typed env (shared group) so there's a
+// single source of truth rather than scattered raw `process.env` reads.
+export const isProduction = env.NODE_ENV === Environment.PRODUCTION;
+export const isDevelopment = env.NODE_ENV === Environment.DEVELOPMENT;
+export const isTest = env.NODE_ENV === Environment.TEST;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { FLUSH, PAUSE, PERSIST, PURGE, REGISTER, REHYDRATE } from 'redux-persist';
 
 import { Environment } from '@/lib/enums';
+import { env } from '@/lib/env';
 
 import { rootReducer } from './rootReducer';
 
@@ -11,7 +12,7 @@ export const makeStore = (preloadedState?: Partial<AppState>) => {
   return configureStore({
     reducer: rootReducer,
     preloadedState: preloadedState as AppState | undefined,
-    devTools: process.env.NODE_ENV !== Environment.PRODUCTION,
+    devTools: env.NODE_ENV !== Environment.PRODUCTION,
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
         serializableCheck: {


### PR DESCRIPTION
## Summary

`constants.ts` and `store/index.ts` read `process.env.NODE_ENV` directly while the rest of the app already goes through the validated `@teispace/env` config. This routes them through `env.NODE_ENV` (the shared group) so the typed, validated env is the single source of truth for runtime config.

## Changes
- `src/lib/config/constants.ts` — `isProduction`/`isDevelopment`/`isTest` now read `env.NODE_ENV`.
- `src/store/index.ts` — `devTools` toggle reads `env.NODE_ENV`.

`next.config.ts`'s `process.env.ANALYZE` is intentionally left raw — it's a build-time toggle, not part of the app's runtime env contract.

## Test plan
- [x] `yarn type-check` clean
- [x] `yarn lint` clean (no new errors)
- [x] `yarn test` — 149 tests pass
